### PR TITLE
Removed Warnings and added an example

### DIFF
--- a/examples/uRTCLib_set_print_Date_Time/uRTCLib_set_print_Date_Time.ino
+++ b/examples/uRTCLib_set_print_Date_Time/uRTCLib_set_print_Date_Time.ino
@@ -1,0 +1,302 @@
+/**
+ * DS1307, DS3231 and DS3232 RTCs basic library
+ *
+ * Really tiny library to basic RTC functionality on Arduino.
+ *
+ * Supported features:
+ *     * SQuare Wave Generator
+ *     * Fixed output pin for DS1307
+ *     * RAM for DS1307 and DS3232
+ *     * temperature sensor for DS3231 and DS3232
+ *     * Alarms (1 and 2) for DS3231 and DS3232
+ *     * Power failure check for DS3231 and DS3232
+ *
+ * See uEEPROMLib for EEPROM support.
+ *
+ * @copyright Naguissa
+ * @author Naguissa / ArminJo
+ * @url https://github.com/Naguissa/uRTCLib
+ * @url https://www.foroelectro.net/librerias-arduino-ide-f29/rtclib-arduino-libreria-simple-y-eficaz-para-rtc-y-t95.html
+ * @email naguissa@foroelectro.net
+ */
+#include "Arduino.h"
+#include "Wire.h"
+#include "uRTCLib.h"
+
+uRTCLib rtc;
+
+#define VERSION_EXAMPLE "1.0"
+
+#define DATE_FORMAT_LONG_MASK 0x01
+#define DATE_FORMAT_AMERICAN 0x02
+#define DATE_FORMAT_AMERICAN_LONG 0x03
+#define DATE_FORMAT_EUROPEAN 0x04
+#define DATE_FORMAT_EUROPEAN_LONG 0x05
+
+void printRTC(uint8_t aDateFormatSpecifier = 0);
+bool printRTCEveryPeriod(uint16_t aPeriodSeconds, uint8_t aDateFormatSpecifier = 0);
+
+void printRTCDate(uint8_t aDateFormatSpecifier = 0);
+void printRTCDateAmericanFormat(bool aPrintLongFormat);
+void printRTCDateEuropeanFormat(bool aPrintLongFormat);
+void printRTCDateISOFormat();
+
+void printRTCTime(bool aPrintLongFormat = true, bool aDoRefresh = false);
+
+void printRTCTemperature();
+bool requestDateBySerialAndSet(void);
+
+#if !defined(__AVR__) && ! defined(PROGMEM)
+#define PROGMEM
+#endif
+
+//#define GERMAN_NAMES_FOR_DATE
+
+#if defined(GERMAN_NAMES_FOR_DATE)
+const char Sunday[] PROGMEM= "Sonntag";
+const char Monday[] PROGMEM= "Montag";
+const char Tuesday[] PROGMEM= "Dienstag";
+const char Wednesday[] PROGMEM= "Mittwoch";
+const char Thursday[] PROGMEM= "Donnerstag";
+const char Friday[] PROGMEM= "Freitag";
+const char Saturday[] PROGMEM= "Samstag";
+
+const char January[] PROGMEM= "Januar";
+const char February[] PROGMEM= "Februar";
+const char March[] PROGMEM= "März";
+const char April[] PROGMEM= "April";
+const char May[] PROGMEM= "Mai";
+const char June[] PROGMEM= "Juni";
+const char July[] PROGMEM= "July";
+const char August[] PROGMEM= "August";
+const char September[] PROGMEM= "September";
+const char October[] PROGMEM= "Oktober";
+const char November[] PROGMEM= "November";
+const char December[] PROGMEM= "Dezember";
+#else
+const char Sunday[] PROGMEM ="Sunday";
+const char Monday[] PROGMEM ="Monday";
+const char Tuesday[] PROGMEM ="Tuesday";
+const char Wednesday[] PROGMEM ="Wednesday";
+const char Thursday[] PROGMEM ="Thursday";
+const char Friday[] PROGMEM ="Friday";
+const char Saturday[] PROGMEM ="Saturday";
+
+const char January[] PROGMEM ="January";
+const char February[] PROGMEM = "February";
+const char March[] PROGMEM = "March";
+const char April[] PROGMEM = "April";
+const char May[] PROGMEM = "May";
+const char June[] PROGMEM = "June";
+const char July[] PROGMEM = "July";
+const char August[] PROGMEM = "August";
+const char September[] PROGMEM = "September";
+const char October[] PROGMEM = "October";
+const char November[] PROGMEM ="November";
+const char December[] PROGMEM = "December";
+#endif
+
+const char* const sDayStrings[] PROGMEM = { Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday };
+#define DOW_MAX_STRING_SIZE 11 // excluding trailing NUL (Donnerstag)
+
+const char* const sMonthStrings[] PROGMEM = { January, February, March, April, May, June, July, August, September, October,
+        November, December };
+#define MONTH_MAX_STRING_SIZE 10 // excluding trailing NUL (September)
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial)
+        ; //delay for Leonardo
+          // Just to know which program is running on my Arduino
+    Serial.println(F("START " __FILE__ "\r\nVersion " VERSION_EXAMPLE " from " __DATE__));
+
+#ifdef ARDUINO_ARCH_ESP8266
+        Wire.begin(0, 2); // D3 and D4 on ESP8266
+    #else
+    Wire.begin();
+#endif
+    rtc.set_rtc_address(0x68);
+    rtc.set_model(URTCLIB_MODEL_DS3232);
+
+    // Only used once, then disabled
+    rtc.set(0, 42, 16, 6, 2, 5, 15);
+    //  RTCLib::set(byte second, byte minute, byte hour, byte dayOfWeek, byte dayOfMonth, byte month, byte year)
+
+    if (rtc.lostPower() || rtc.year() < 19) {
+        if (requestDateBySerialAndSet()) {
+            rtc.lostPowerClear();
+        }
+    }
+}
+
+void loop() {
+
+    /*
+     * Print date and time each second in 5 different formats
+     */
+    if (printRTCEveryPeriod(1)) {
+        printRTC(DATE_FORMAT_EUROPEAN);
+        printRTC(DATE_FORMAT_EUROPEAN_LONG);
+        printRTC(DATE_FORMAT_AMERICAN);
+        printRTC(DATE_FORMAT_AMERICAN_LONG);
+        Serial.println();
+    }
+    delay(1000);
+}
+
+bool requestDateBySerialAndSet(void) {
+
+    uint8_t tSecond, tMinute, tHour, tDayOfMonth, tMonth, tYear;
+    char tInputBuffer[17];
+    Serial.println();
+    Serial.println(F("Enter the time in format: \"HH MM SS DD MM YY\" - Timeout is 30 seconds"));
+    Serial.setTimeout(30000);
+    // read exactly 17 characters
+    size_t tReadLength = Serial.readBytes(tInputBuffer, 17);
+    if (tReadLength == 17 && tInputBuffer[14] == ' ') {
+        sscanf_P(tInputBuffer, PSTR("%2hhu %2hhu %2hhu %2hhu %2hhu %2hhu"), &tHour, &tMinute, &tSecond, &tDayOfMonth, &tMonth,
+                &tYear);
+        // read newline etc.
+        while (Serial.available()) {
+            Serial.read();
+        }
+        Serial.setTimeout(10000);
+        Serial.println();
+        Serial.println(F("Enter the day of week as number between 1 and 7 (Sunday-Saturday) - Timeout is 10 seconds"));
+        Serial.readBytes(tInputBuffer, 1);
+        if (tInputBuffer[0] > '0' && tInputBuffer[0] < '8') {
+            rtc.set(tSecond, tMinute, tHour, tInputBuffer[0] - '0', tDayOfMonth, tMonth, tYear);
+            Serial.print(F("Time set to: "));
+            printRTC();
+            return true;
+        }
+    }
+    Serial.println(F("Clock has not been changed, press reset for next try."));
+    return false;
+}
+
+/*
+ * @return true if update/refresh happened
+ */
+bool printRTCEveryPeriod(uint16_t aPeriodSeconds, uint8_t aDateFormatSpecifier) {
+    static long sLastMillisOfRTCRead;
+    if (millis() - sLastMillisOfRTCRead >= (1000 * aPeriodSeconds)) {
+        sLastMillisOfRTCRead = millis();
+        rtc.refresh();
+        printRTC(aDateFormatSpecifier);
+        return true;
+    }
+    return false;
+}
+
+void printRTC(uint8_t aDateFormatSpecifier) {
+    rtc.refresh();
+    printRTCDate(aDateFormatSpecifier);
+    Serial.print(' ');
+    printRTCTime((aDateFormatSpecifier & DATE_FORMAT_LONG_MASK), false);
+    Serial.println();
+}
+
+void printRTCDateAmericanFormat(bool aPrintLongFormat) {
+#if defined(__AVR__)
+    char tDateString[(2 * DOW_MAX_STRING_SIZE) + 1 + (2 * MONTH_MAX_STRING_SIZE) + 1 + 12];
+#else
+    char tDateString[DOW_MAX_STRING_SIZE + MONTH_MAX_STRING_SIZE + 12];
+#endif
+
+    if (aPrintLongFormat) {
+#if defined(__AVR__)
+        // fist copy day of week
+        strcpy_P(&tDateString[sizeof(tDateString) - (DOW_MAX_STRING_SIZE + MONTH_MAX_STRING_SIZE) - 3],
+                (PGM_P) pgm_read_word(&sDayStrings[rtc.dayOfWeek() - 1]));
+        strcpy_P(&tDateString[sizeof(tDateString) - (MONTH_MAX_STRING_SIZE) - 2],
+                (PGM_P) pgm_read_word(&sMonthStrings[rtc.month() - 1]));
+        sprintf_P(tDateString, PSTR("%s, %s %2hhu, 20%2hhu"),
+                &tDateString[sizeof(tDateString) - (DOW_MAX_STRING_SIZE + MONTH_MAX_STRING_SIZE) - 3],
+                &tDateString[sizeof(tDateString) - (MONTH_MAX_STRING_SIZE) - 2], rtc.day(), rtc.year());
+#else
+        sprintf(tDateString, "%s, %s %2hhu, 20%2hhu", sDayStrings[rtc.dayOfWeek() - 1],
+                sMonthStrings[rtc.month() - 1], rtc.day(), rtc.year());
+#endif
+    } else {
+        sprintf_P(tDateString, PSTR("%02hhu/%02hhu/20%2hhu"), rtc.month(), rtc.day(), rtc.year());
+    }
+    Serial.print(tDateString);
+}
+
+void printRTCDateEuropeanFormat(bool aPrintLongFormat) {
+#if defined(__AVR__)
+    char tDateString[(2 * DOW_MAX_STRING_SIZE) + 1 + (2 * MONTH_MAX_STRING_SIZE) + 1 + 12];
+#else
+    char tDateString[DOW_MAX_STRING_SIZE + MONTH_MAX_STRING_SIZE + 12];
+#endif
+
+    if (aPrintLongFormat) {
+#if defined(__AVR__)
+        // fist copy day of week
+        strcpy_P(&tDateString[sizeof(tDateString) - (DOW_MAX_STRING_SIZE + MONTH_MAX_STRING_SIZE) - 3],
+                (PGM_P) pgm_read_word(&sDayStrings[rtc.dayOfWeek() - 1]));
+        strcpy_P(&tDateString[sizeof(tDateString) - (MONTH_MAX_STRING_SIZE) - 2],
+                (PGM_P) pgm_read_word(&sMonthStrings[rtc.month() - 1]));
+        sprintf_P(tDateString, PSTR("%s, %2hhu. %s 20%2hhu"),
+                &tDateString[sizeof(tDateString) - (DOW_MAX_STRING_SIZE + MONTH_MAX_STRING_SIZE) - 3], rtc.day(),
+                &tDateString[sizeof(tDateString) - (MONTH_MAX_STRING_SIZE) - 2], rtc.year());
+#else
+        sprintf(tDateString, "%s, %2hhu. %s 20%2hhu", sDayStrings[rtc.dayOfWeek() - 1], rtc.day(),
+                sMonthStrings[rtc.month() - 1], rtc.year());
+#endif
+    } else {
+        sprintf_P(tDateString, PSTR("%02hhu.%02hhu.20%2hhu"), rtc.day(), rtc.month(), rtc.year());
+    }
+    Serial.print(tDateString);
+}
+
+void printRTCDateISOFormat() {
+    char tDateString[11];
+#if defined(__AVR__)
+    sprintf_P(tDateString, PSTR("20%2hhu-%02hhu-%02hhu"), rtc.year(), rtc.month(), rtc.day());
+#else
+    sprintf(tDateString, "20%2hhu-%02hhu-%02hhu", rtc.year(), rtc.month(), rtc.day());
+#endif
+    Serial.print(tDateString);
+}
+
+void printRTCDate(uint8_t aDateFormatSpecifier) {
+
+    if (aDateFormatSpecifier & DATE_FORMAT_AMERICAN) {
+        printRTCDateAmericanFormat((aDateFormatSpecifier & DATE_FORMAT_LONG_MASK));
+    } else if (aDateFormatSpecifier & DATE_FORMAT_EUROPEAN) {
+        printRTCDateEuropeanFormat((aDateFormatSpecifier & DATE_FORMAT_LONG_MASK));
+    } else {
+// ISO Format
+        printRTCDateISOFormat();
+    }
+}
+
+void printRTCTemperature() {
+    Serial.print(rtc.temp() / 100);
+    Serial.print('.');
+    Serial.print(rtc.temp() - ((rtc.temp() / 100) * 100));
+}
+
+void printRTCTime(bool aPrintLongFormat, bool aDoRefresh) {
+    if (aDoRefresh) {
+        rtc.refresh();
+    }
+    char tTimeString[9]; // 8 + trailing NUL character
+#if defined(__AVR__)
+    if (aPrintLongFormat) {
+        sprintf_P(tTimeString, PSTR("%02hhu:%02hhu:%02hhu"), rtc.hour(), rtc.minute(), rtc.second());
+    } else {
+        sprintf_P(tTimeString, PSTR("%02hhu:%02hhu"), rtc.hour(), rtc.minute());
+    }
+#else
+    if (aPrintLongFormat) {
+        sprintf(tTimeString, "%02hhu:%02hhu:%02hhu", rtc.hour(), rtc.minute(), rtc.second());
+    } else {
+        sprintf(tTimeString, "%02hhu:%02hhu", rtc.hour(), rtc.minute());
+    }
+#endif
+    Serial.print(tTimeString);
+}
+

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -39,7 +39,7 @@ uRTCLib::uRTCLib() { }
  * @param rtc_address I2C address of RTC
  */
 uRTCLib::uRTCLib(const int rtc_address) {
-	_rtc_address = rtc_address;
+    _rtc_address = rtc_address;
 }
 
 /**
@@ -52,179 +52,179 @@ uRTCLib::uRTCLib(const int rtc_address) {
  *     - #URTCLIB_MODEL_DS3232
  */
 uRTCLib::uRTCLib(const int rtc_address, const uint8_t model) {
-	_rtc_address = rtc_address;
-	_model = model;
+    _rtc_address = rtc_address;
+    _model = model;
 }
 
 /**
  * \brief Refresh data from HW RTC
  */
 void uRTCLib::refresh() {
-	uRTCLIB_YIELD
-	Wire.beginTransmission(_rtc_address);
-	Wire.write(0); // set DS3231 register pointer to 00h
-	Wire.endTransmission();
-	uRTCLIB_YIELD
+    uRTCLIB_YIELD
+    Wire.beginTransmission(_rtc_address);
+    Wire.write(0); // set DS3231 register pointer to 00h
+    Wire.endTransmission();
+    uRTCLIB_YIELD
 
-	// Adjust requested bytes to selected model:
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			Wire.requestFrom(_rtc_address, 8);
-			break;
+    // Adjust requested bytes to selected model:
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            Wire.requestFrom(_rtc_address, 8);
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			Wire.requestFrom(_rtc_address, 15);
-			break;
-	}
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            Wire.requestFrom(_rtc_address, 15);
+            break;
+    }
 
-	_second = Wire.read();
-	uRTCLIB_YIELD
-	_second = uRTCLIB_bcdToDec(_second);
+    _second = Wire.read();
+    uRTCLIB_YIELD
+    _second = uRTCLIB_bcdToDec(_second);
 
-	_minute = Wire.read();
-	uRTCLIB_YIELD
-	_minute = uRTCLIB_bcdToDec(_minute);
+    _minute = Wire.read();
+    uRTCLIB_YIELD
+    _minute = uRTCLIB_bcdToDec(_minute);
 
-	_hour = Wire.read() & 0b111111;
-	uRTCLIB_YIELD
-	_hour = uRTCLIB_bcdToDec(_hour);
+    _hour = Wire.read() & 0b111111;
+    uRTCLIB_YIELD
+    _hour = uRTCLIB_bcdToDec(_hour);
 
-	_dayOfWeek = Wire.read();
-	uRTCLIB_YIELD
-	_dayOfWeek = uRTCLIB_bcdToDec(_dayOfWeek);
+    _dayOfWeek = Wire.read();
+    uRTCLIB_YIELD
+    _dayOfWeek = uRTCLIB_bcdToDec(_dayOfWeek);
 
-	_day = Wire.read();
-	uRTCLIB_YIELD
-	_day = uRTCLIB_bcdToDec(_day);
+    _day = Wire.read();
+    uRTCLIB_YIELD
+    _day = uRTCLIB_bcdToDec(_day);
 
-	_month = Wire.read();
-	uRTCLIB_YIELD
-	_month = uRTCLIB_bcdToDec(_month);
+    _month = Wire.read();
+    uRTCLIB_YIELD
+    _month = uRTCLIB_bcdToDec(_month);
 
-	_year = Wire.read();
-	uRTCLIB_YIELD
-	_year = uRTCLIB_bcdToDec(_year);
+    _year = Wire.read();
+    uRTCLIB_YIELD
+    _year = uRTCLIB_bcdToDec(_year);
 
-	_temp = 9999; // Some obvious error value
+    _temp = 9999; // Some obvious error value
 
-	// Now we need to read extra requested bytes depending on the RTC model again:
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			uint8_t status;
-			status = Wire.read();
-			if (status & 0b00010000) {
-				_sqwg_mode = status & 0b10000000 ? URTCLIB_SQWG_OFF_1 : URTCLIB_SQWG_OFF_0;
-			} else {
-				switch (status & 0b00000011) {
-					case 0x00000011:
-						_sqwg_mode = URTCLIB_SQWG_32768H;
-						break;
+    // Now we need to read extra requested bytes depending on the RTC model again:
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            uint8_t status;
+            status = Wire.read();
+            if (status & 0b00010000) {
+                _sqwg_mode = status & 0b10000000 ? URTCLIB_SQWG_OFF_1 : URTCLIB_SQWG_OFF_0;
+            } else {
+                switch (status & 0b00000011) {
+                    case 0x00000011:
+                        _sqwg_mode = URTCLIB_SQWG_32768H;
+                        break;
 
-					case 0x00000010:
-						_sqwg_mode = URTCLIB_SQWG_8192H;
-						break;
+                    case 0x00000010:
+                        _sqwg_mode = URTCLIB_SQWG_8192H;
+                        break;
 
-					case 0x00000001:
-						_sqwg_mode = URTCLIB_SQWG_4096H;
-						break;
+                    case 0x00000001:
+                        _sqwg_mode = URTCLIB_SQWG_4096H;
+                        break;
 
-					// case 0x00000000:
-					default:
-						_sqwg_mode = URTCLIB_SQWG_1H;
-						break;
-				}
-			}
-			break;
+                    // case 0x00000000:
+                    default:
+                        _sqwg_mode = URTCLIB_SQWG_1H;
+                        break;
+                }
+            }
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			uint8_t MSB, LSB; // LSB is also used as tmp  variable
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            uint8_t MSB, LSB; // LSB is also used as tmp  variable
 
-			_a1_mode = 0b00000000;
-			_a2_mode = 0b10000000;
+            _a1_mode = 0b00000000;
+            _a2_mode = 0b10000000;
 
-			_a1_second = Wire.read();
-			uRTCLIB_YIELD
-			_a1_mode = _a1_mode | ((_a1_second & 0b10000000) >> 7);
-			_a1_second = uRTCLIB_bcdToDec(_a1_second);
+            _a1_second = Wire.read();
+            uRTCLIB_YIELD
+            _a1_mode = _a1_mode | ((_a1_second & 0b10000000) >> 7);
+            _a1_second = uRTCLIB_bcdToDec(_a1_second);
 
-			_a1_minute = Wire.read();
-			uRTCLIB_YIELD
-			_a1_mode = _a1_mode | ((_a1_minute & 0b10000000) >> 6);
-			_a1_minute = uRTCLIB_bcdToDec(_a1_minute);
+            _a1_minute = Wire.read();
+            uRTCLIB_YIELD
+            _a1_mode = _a1_mode | ((_a1_minute & 0b10000000) >> 6);
+            _a1_minute = uRTCLIB_bcdToDec(_a1_minute);
 
-			_a1_hour = Wire.read() & 0b111111;
-			uRTCLIB_YIELD
-			_a1_mode = _a1_mode | ((_a1_hour & 0b10000000) >> 5);
-			_a1_hour = uRTCLIB_bcdToDec(_a1_hour);
+            _a1_hour = Wire.read() & 0b111111;
+            uRTCLIB_YIELD
+            _a1_mode = _a1_mode | ((_a1_hour & 0b10000000) >> 5);
+            _a1_hour = uRTCLIB_bcdToDec(_a1_hour);
 
-			_a1_day_dow = Wire.read();
-			uRTCLIB_YIELD
-			_a1_mode = _a1_mode | ((_a1_day_dow & 0b10000000) >> 4);
-			if (!(_a1_mode & 0b00001111)) {
-				_a1_mode = _a1_mode | ((_a1_day_dow & 0b01000000) >> 3);
-			}
-			_a1_day_dow = uRTCLIB_bcdToDec(_a2_day_dow);
+            _a1_day_dow = Wire.read();
+            uRTCLIB_YIELD
+            _a1_mode = _a1_mode | ((_a1_day_dow & 0b10000000) >> 4);
+            if (!(_a1_mode & 0b00001111)) {
+                _a1_mode = _a1_mode | ((_a1_day_dow & 0b01000000) >> 3);
+            }
+            _a1_day_dow = uRTCLIB_bcdToDec(_a2_day_dow);
 
-			_a2_minute = Wire.read();
-			uRTCLIB_YIELD
-			_a2_mode = _a2_mode | ((_a2_minute & 0b10000000) >> 7);
-			_a2_minute = uRTCLIB_bcdToDec(_a2_minute);
+            _a2_minute = Wire.read();
+            uRTCLIB_YIELD
+            _a2_mode = _a2_mode | ((_a2_minute & 0b10000000) >> 7);
+            _a2_minute = uRTCLIB_bcdToDec(_a2_minute);
 
-			_a2_hour = Wire.read() & 0b111111;
-			uRTCLIB_YIELD
-			_a2_mode = _a2_mode | ((_a2_hour & 0b10000000) >> 6);
-			_a2_hour = uRTCLIB_bcdToDec(_a2_hour);
+            _a2_hour = Wire.read() & 0b111111;
+            uRTCLIB_YIELD
+            _a2_mode = _a2_mode | ((_a2_hour & 0b10000000) >> 6);
+            _a2_hour = uRTCLIB_bcdToDec(_a2_hour);
 
-			_a2_day_dow = Wire.read();
-			uRTCLIB_YIELD
-			_a2_mode = _a2_mode | ((_a2_day_dow & 0b10000000) >> 5);
-			if (!(_a2_mode & 0b00000111)) {
-				_a2_mode = _a2_mode | ((_a2_day_dow & 0b01000000) >> 4);
-			}
-			_a2_day_dow = uRTCLIB_bcdToDec(_a2_day_dow);
+            _a2_day_dow = Wire.read();
+            uRTCLIB_YIELD
+            _a2_mode = _a2_mode | ((_a2_day_dow & 0b10000000) >> 5);
+            if (!(_a2_mode & 0b00000111)) {
+                _a2_mode = _a2_mode | ((_a2_day_dow & 0b01000000) >> 4);
+            }
+            _a2_day_dow = uRTCLIB_bcdToDec(_a2_day_dow);
 
 
-			// Control registers
-			LSB = Wire.read();
-			uRTCLIB_YIELD
+            // Control registers
+            LSB = Wire.read();
+            uRTCLIB_YIELD
 
-			if (LSB & 0b00000100) {
-				_sqwg_mode = URTCLIB_SQWG_OFF_1;
-				// Alarms disabled?
-				if (!(LSB & 0b00000001)) {
-					_a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
-				}
-				if (!(LSB & 0b00000010)) {
-					_a2_mode = URTCLIB_ALARM_TYPE_2_NONE;
-				}
-			} else {
-				_sqwg_mode = LSB & 0b00011000;
-				// Mark alarms as disabled because the SQWG:
-				_a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
-				_a2_mode = URTCLIB_ALARM_TYPE_2_NONE;
-			}
+            if (LSB & 0b00000100) {
+                _sqwg_mode = URTCLIB_SQWG_OFF_1;
+                // Alarms disabled?
+                if (!(LSB & 0b00000001)) {
+                    _a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
+                }
+                if (!(LSB & 0b00000010)) {
+                    _a2_mode = URTCLIB_ALARM_TYPE_2_NONE;
+                }
+            } else {
+                _sqwg_mode = LSB & 0b00011000;
+                // Mark alarms as disabled because the SQWG:
+                _a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
+                _a2_mode = URTCLIB_ALARM_TYPE_2_NONE;
+            }
 
-			// Temperature registers (11h-12h) get updated automatically every 64s
-			Wire.beginTransmission(_rtc_address);
-			Wire.write(0x11);
-			Wire.endTransmission();
-			Wire.requestFrom(_rtc_address, 2);
-			uRTCLIB_YIELD
+            // Temperature registers (11h-12h) get updated automatically every 64s
+            Wire.beginTransmission(_rtc_address);
+            Wire.write(0x11);
+            Wire.endTransmission();
+            Wire.requestFrom(_rtc_address, 2);
+            uRTCLIB_YIELD
 
-			MSB = Wire.read(); //2's complement int portion
-			LSB = Wire.read(); //fraction portion
-			_temp = 0b0000000000000000 | (MSB  << 2) | (LSB >> 6); // 8+2 bits, *25 is the same as number + 2bitdecimals * 100 in base 10
-			if (MSB & 0b10000000) {
-				_temp = (_temp | 0b1111110000000000);
-				_temp--;
-			}
-			_temp = _temp * 25; // *25 is the same as number + 2bit (decimals) * 100 in base 10
-			break;
-	}
+            MSB = Wire.read(); //2's complement int portion
+            LSB = Wire.read(); //fraction portion
+            _temp = 0b0000000000000000 | (MSB  << 2) | (LSB >> 6); // 8+2 bits, *25 is the same as number + 2bitdecimals * 100 in base 10
+            if (MSB & 0b10000000) {
+                _temp = (_temp | 0b1111110000000000);
+                _temp--;
+            }
+            _temp = _temp * 25; // *25 is the same as number + 2bit (decimals) * 100 in base 10
+            break;
+    }
 }
 
 /**
@@ -237,25 +237,25 @@ void uRTCLib::refresh() {
 bool uRTCLib::lostPower() {
 
 
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return false;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return false;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			uRTCLIB_YIELD
-			Wire.beginTransmission(_rtc_address);
-			Wire.write(0X0F);
-			Wire.endTransmission();
-			uRTCLIB_YIELD
-			Wire.requestFrom(_rtc_address, 1);
-			uint8_t status = Wire.read();
-			uRTCLIB_YIELD
-			return ((status & 0B10000000) == 0B10000000);
-			break;
-	}
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            uRTCLIB_YIELD
+            Wire.beginTransmission(_rtc_address);
+            Wire.write(0X0F);
+            Wire.endTransmission();
+            uRTCLIB_YIELD
+            Wire.requestFrom(_rtc_address, 1);
+            uint8_t status = Wire.read();
+            uRTCLIB_YIELD
+            return ((status & 0B10000000) == 0B10000000);
+            break;
+    }
 }
 
 /**
@@ -266,32 +266,32 @@ bool uRTCLib::lostPower() {
 void uRTCLib::lostPowerClear() {
 
 
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			uRTCLIB_YIELD
-			Wire.beginTransmission(_rtc_address);
-			Wire.write(0X0F);
-			Wire.endTransmission();
-			uRTCLIB_YIELD
-			Wire.requestFrom(_rtc_address, 1);
-			uint8_t status = Wire.read();
-			status &= 0b01111111;
-			uRTCLIB_YIELD
-			Wire.beginTransmission(_rtc_address);
-			uRTCLIB_YIELD
-			Wire.write(0x0F);
-			uRTCLIB_YIELD
-			Wire.write(status);
-			uRTCLIB_YIELD
-			Wire.endTransmission();
-			uRTCLIB_YIELD
-			break;
-	}
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            uRTCLIB_YIELD
+            Wire.beginTransmission(_rtc_address);
+            Wire.write(0X0F);
+            Wire.endTransmission();
+            uRTCLIB_YIELD
+            Wire.requestFrom(_rtc_address, 1);
+            uint8_t status = Wire.read();
+            status &= 0b01111111;
+            uRTCLIB_YIELD
+            Wire.beginTransmission(_rtc_address);
+            uRTCLIB_YIELD
+            Wire.write(0x0F);
+            uRTCLIB_YIELD
+            Wire.write(status);
+            uRTCLIB_YIELD
+            Wire.endTransmission();
+            uRTCLIB_YIELD
+            break;
+    }
 }
 
 /**
@@ -304,10 +304,10 @@ void uRTCLib::lostPowerClear() {
  * @return Current stored temperature
  */
 int16_t uRTCLib::temp() {
-	if (_model == URTCLIB_MODEL_DS1307) {
-		return URTCLIB_TEMP_ERROR;
-	}
-	return _temp;
+    if (_model == URTCLIB_MODEL_DS1307) {
+        return URTCLIB_TEMP_ERROR;
+    }
+    return _temp;
 }
 
 /**
@@ -316,7 +316,7 @@ int16_t uRTCLib::temp() {
  * @return Current stored second
  */
 uint8_t uRTCLib::second() {
-	return _second;
+    return _second;
 }
 
 /**
@@ -325,7 +325,7 @@ uint8_t uRTCLib::second() {
  * @return Current stored minute
  */
 uint8_t uRTCLib::minute() {
-	return _minute;
+    return _minute;
 }
 
 
@@ -335,7 +335,7 @@ uint8_t uRTCLib::minute() {
  * @return Current stored hour
  */
 uint8_t uRTCLib::hour() {
-	return _hour;
+    return _hour;
 }
 
 /**
@@ -344,7 +344,7 @@ uint8_t uRTCLib::hour() {
  * @return Current stored day
  */
 uint8_t uRTCLib::day() {
-	return _day;
+    return _day;
 }
 
 /**
@@ -353,7 +353,7 @@ uint8_t uRTCLib::day() {
  * @return Current stored month
  */
 uint8_t uRTCLib::month() {
-	return _month;
+    return _month;
 }
 
 /**
@@ -362,7 +362,7 @@ uint8_t uRTCLib::month() {
  * @return Current stored year
  */
 uint8_t uRTCLib::year() {
-	return _year;
+    return _year;
 }
 
 /**
@@ -371,7 +371,7 @@ uint8_t uRTCLib::year() {
  * @return Current stored Day Of Week
  */
 uint8_t uRTCLib::dayOfWeek() {
-	return _dayOfWeek;
+    return _dayOfWeek;
 }
 
 
@@ -381,7 +381,7 @@ uint8_t uRTCLib::dayOfWeek() {
  * @param addr RTC i2C address
  */
 void uRTCLib::set_rtc_address(const int addr) {
-	_rtc_address = addr;
+    _rtc_address = addr;
 }
 
 
@@ -394,7 +394,7 @@ void uRTCLib::set_rtc_address(const int addr) {
  *     - #URTCLIB_MODEL_DS3232
  */
 void uRTCLib::set_model(const uint8_t model) {
-	_model = model;
+    _model = model;
 }
 
 /**
@@ -406,7 +406,7 @@ void uRTCLib::set_model(const uint8_t model) {
  *     - #URTCLIB_MODEL_DS3232
  */
 uint8_t uRTCLib::model() {
-	return _model;
+    return _model;
 }
 
 /**
@@ -421,33 +421,33 @@ uint8_t uRTCLib::model() {
  * @param year year to set to HW RTC
  */
 void uRTCLib::set(const uint8_t second, const uint8_t minute, const uint8_t hour, const uint8_t dayOfWeek, const uint8_t dayOfMonth, const uint8_t month, const uint8_t year) {
-	uRTCLIB_YIELD
-	Wire.beginTransmission(_rtc_address);
-	Wire.write(0); // set next input to start at the seconds register
-	Wire.write(uRTCLIB_decToBcd(second)); // set seconds
-	Wire.write(uRTCLIB_decToBcd(minute)); // set minutes
-	Wire.write(uRTCLIB_decToBcd(hour)); // set hours
-	Wire.write(uRTCLIB_decToBcd(dayOfWeek)); // set day of week (1=Sunday, 7=Saturday)
-	Wire.write(uRTCLIB_decToBcd(dayOfMonth)); // set date (1 to 31)
-	Wire.write(uRTCLIB_decToBcd(month)); // set month
-	Wire.write(uRTCLIB_decToBcd(year)); // set year (0 to 99)
-	Wire.endTransmission();
-	uRTCLIB_YIELD
-	//
-	Wire.beginTransmission(_rtc_address);
-	Wire.write(0X0F);
-	Wire.endTransmission();
-	uRTCLIB_YIELD
-	/* flip OSF bit --> Disabled, use lostPowerClear instead.
-	Wire.requestFrom(_rtc_address, 1);
-	uint8_t statreg = Wire.read();
-	statreg &= ~0x80;
-	uRTCLIB_YIELD
-	Wire.beginTransmission(_rtc_address);
-	Wire.write(0X0F);
-	Wire.write((byte)statreg);
-	Wire.endTransmission();
-	*/
+    uRTCLIB_YIELD
+    Wire.beginTransmission(_rtc_address);
+    Wire.write(0); // set next input to start at the seconds register
+    Wire.write(uRTCLIB_decToBcd(second)); // set seconds
+    Wire.write(uRTCLIB_decToBcd(minute)); // set minutes
+    Wire.write(uRTCLIB_decToBcd(hour)); // set hours
+    Wire.write(uRTCLIB_decToBcd(dayOfWeek)); // set day of week (1=Sunday, 7=Saturday)
+    Wire.write(uRTCLIB_decToBcd(dayOfMonth)); // set date (1 to 31)
+    Wire.write(uRTCLIB_decToBcd(month)); // set month
+    Wire.write(uRTCLIB_decToBcd(year)); // set year (0 to 99)
+    Wire.endTransmission();
+    uRTCLIB_YIELD
+    //
+    Wire.beginTransmission(_rtc_address);
+    Wire.write(0X0F);
+    Wire.endTransmission();
+    uRTCLIB_YIELD
+    /* flip OSF bit --> Disabled, use lostPowerClear instead.
+    Wire.requestFrom(_rtc_address, 1);
+    uint8_t statreg = Wire.read();
+    statreg &= ~0x80;
+    uRTCLIB_YIELD
+    Wire.beginTransmission(_rtc_address);
+    Wire.write(0X0F);
+    Wire.write((byte)statreg);
+    Wire.endTransmission();
+    */
 }
 
 
@@ -482,159 +482,159 @@ void uRTCLib::set(const uint8_t second, const uint8_t minute, const uint8_t hour
  * @return false in case of not supported (DS1307) or wrong parameters
  */
 bool uRTCLib::alarmSet(const uint8_t type, const uint8_t second, const uint8_t minute, const uint8_t hour, const uint8_t day_dow) {
-	bool ret = false;
-	uint8_t status;
+    bool ret = false;
+    uint8_t status;
 
-	uRTCLIB_YIELD
+    uRTCLIB_YIELD
 
-	if (type == URTCLIB_ALARM_TYPE_1_NONE) {
-		ret = true;
+    if (type == URTCLIB_ALARM_TYPE_1_NONE) {
+        ret = true;
 
-		// Disable Alarm:
-		Wire.beginTransmission(_rtc_address);
-		uRTCLIB_YIELD
-		Wire.write(0x0E);
-		uRTCLIB_YIELD
-		Wire.endTransmission();
-		uRTCLIB_YIELD
-		Wire.requestFrom(_rtc_address, 1);
-		status = Wire.read();
-		status &= 0b11111110;
-		Wire.beginTransmission(_rtc_address);
-		uRTCLIB_YIELD
-		Wire.write(0x0E);
-		uRTCLIB_YIELD
-		Wire.write(status);
-		uRTCLIB_YIELD
-		Wire.endTransmission();
-		uRTCLIB_YIELD
-		_a1_mode = type;
-	} else if (type == URTCLIB_ALARM_TYPE_2_NONE) {
-		ret = true;
+        // Disable Alarm:
+        Wire.beginTransmission(_rtc_address);
+        uRTCLIB_YIELD
+        Wire.write(0x0E);
+        uRTCLIB_YIELD
+        Wire.endTransmission();
+        uRTCLIB_YIELD
+        Wire.requestFrom(_rtc_address, 1);
+        status = Wire.read();
+        status &= 0b11111110;
+        Wire.beginTransmission(_rtc_address);
+        uRTCLIB_YIELD
+        Wire.write(0x0E);
+        uRTCLIB_YIELD
+        Wire.write(status);
+        uRTCLIB_YIELD
+        Wire.endTransmission();
+        uRTCLIB_YIELD
+        _a1_mode = type;
+    } else if (type == URTCLIB_ALARM_TYPE_2_NONE) {
+        ret = true;
 
-		// Disable Alarm:
-		Wire.beginTransmission(_rtc_address);
-		uRTCLIB_YIELD
-		Wire.write(0x0E);
-		uRTCLIB_YIELD
-		Wire.endTransmission();
-		uRTCLIB_YIELD
-		Wire.requestFrom(_rtc_address, 1);
-		status = Wire.read();
-		status &= 0b11111101;
-		Wire.beginTransmission(_rtc_address);
-		uRTCLIB_YIELD
-		Wire.write(0x0E);
-		uRTCLIB_YIELD
-		Wire.write(status);
-		uRTCLIB_YIELD
-		Wire.endTransmission();
-		uRTCLIB_YIELD
-		_a2_mode = type;
-	} else {
-		switch (_model) {
-			case URTCLIB_MODEL_DS1307:
-				ret = false;
-				break;
+        // Disable Alarm:
+        Wire.beginTransmission(_rtc_address);
+        uRTCLIB_YIELD
+        Wire.write(0x0E);
+        uRTCLIB_YIELD
+        Wire.endTransmission();
+        uRTCLIB_YIELD
+        Wire.requestFrom(_rtc_address, 1);
+        status = Wire.read();
+        status &= 0b11111101;
+        Wire.beginTransmission(_rtc_address);
+        uRTCLIB_YIELD
+        Wire.write(0x0E);
+        uRTCLIB_YIELD
+        Wire.write(status);
+        uRTCLIB_YIELD
+        Wire.endTransmission();
+        uRTCLIB_YIELD
+        _a2_mode = type;
+    } else {
+        switch (_model) {
+            case URTCLIB_MODEL_DS1307:
+                ret = false;
+                break;
 
-			// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-			// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-			default:
-				switch (type & 0b11000000) {
-					case 0b00000000: // Alarm 1
-						ret = true;
-						Wire.beginTransmission(_rtc_address);
-						uRTCLIB_YIELD
-						Wire.write(0x07); // set next input to start at the seconds register
-						uRTCLIB_YIELD
-						Wire.write(uRTCLIB_decToBcd(second) & 0b01111111 | ((type & 0b00000001) << 7)); // set seconds & mode/bit0
-						uRTCLIB_YIELD
-						Wire.write(uRTCLIB_decToBcd(minute) & 0b01111111 | ((type & 0b00000010) << 6)); // set minutes & mode/bit1
-						uRTCLIB_YIELD
-						Wire.write(uRTCLIB_decToBcd(hour) & 0b01111111 | ((type & 0b00000100) << 5)); // set hours & mode/bit2
-						uRTCLIB_YIELD
-						Wire.write(uRTCLIB_decToBcd(day_dow) & 0b00111111 | ((type & 0b00011000) << 3)); // set date / day of week (1=Sunday, 7=Saturday)  & mode/bit3 & mode/DY-DT (bit4)
-						uRTCLIB_YIELD
-						Wire.endTransmission();
-						uRTCLIB_YIELD
+            // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+            // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+            default:
+                switch (type & 0b11000000) {
+                    case 0b00000000: // Alarm 1
+                        ret = true;
+                        Wire.beginTransmission(_rtc_address);
+                        uRTCLIB_YIELD
+                        Wire.write(0x07); // set next input to start at the seconds register
+                        uRTCLIB_YIELD
+                        Wire.write((uRTCLIB_decToBcd(second) & 0b01111111) | ((type & 0b00000001) << 7)); // set seconds & mode/bit0
+                        uRTCLIB_YIELD
+                        Wire.write((uRTCLIB_decToBcd(minute) & 0b01111111) | ((type & 0b00000010) << 6)); // set minutes & mode/bit1
+                        uRTCLIB_YIELD
+                        Wire.write((uRTCLIB_decToBcd(hour) & 0b01111111) | ((type & 0b00000100) << 5)); // set hours & mode/bit2
+                        uRTCLIB_YIELD
+                        Wire.write((uRTCLIB_decToBcd(day_dow) & 0b00111111) | ((type & 0b00011000) << 3)); // set date / day of week (1=Sunday, 7=Saturday)  & mode/bit3 & mode/DY-DT (bit4)
+                        uRTCLIB_YIELD
+                        Wire.endTransmission();
+                        uRTCLIB_YIELD
 
-						// Enable Alarm:
-						Wire.beginTransmission(_rtc_address);
-						uRTCLIB_YIELD
-						Wire.write(0x0E);
-						uRTCLIB_YIELD
-						Wire.endTransmission();
-						uRTCLIB_YIELD
-						Wire.requestFrom(_rtc_address, 1);
-						uRTCLIB_YIELD
-						status = Wire.read();
-						status = status | 0b00000101;  // INTCN and A1IE bits
-						Wire.beginTransmission(_rtc_address);
-						uRTCLIB_YIELD
-						Wire.write(0x0E);
-						uRTCLIB_YIELD
-						Wire.write(status);
-						uRTCLIB_YIELD
-						Wire.endTransmission();
-						uRTCLIB_YIELD
+                        // Enable Alarm:
+                        Wire.beginTransmission(_rtc_address);
+                        uRTCLIB_YIELD
+                        Wire.write(0x0E);
+                        uRTCLIB_YIELD
+                        Wire.endTransmission();
+                        uRTCLIB_YIELD
+                        Wire.requestFrom(_rtc_address, 1);
+                        uRTCLIB_YIELD
+                        status = Wire.read();
+                        status = status | 0b00000101;  // INTCN and A1IE bits
+                        Wire.beginTransmission(_rtc_address);
+                        uRTCLIB_YIELD
+                        Wire.write(0x0E);
+                        uRTCLIB_YIELD
+                        Wire.write(status);
+                        uRTCLIB_YIELD
+                        Wire.endTransmission();
+                        uRTCLIB_YIELD
 
-						_a1_mode = type;
-						_a1_second = second;
-						_a1_minute = minute;
-						_a1_hour = hour;
-						_a1_day_dow = day_dow;
-						_sqwg_mode = URTCLIB_SQWG_OFF_1;
+                        _a1_mode = type;
+                        _a1_second = second;
+                        _a1_minute = minute;
+                        _a1_hour = hour;
+                        _a1_day_dow = day_dow;
+                        _sqwg_mode = URTCLIB_SQWG_OFF_1;
 
-						break;
+                        break;
 
-					case 0b10000000: // Alarm 2
-						ret = true;
-						Wire.beginTransmission(_rtc_address);
-						uRTCLIB_YIELD
-						Wire.write(0x07); // set next input to start at the seconds register
-						uRTCLIB_YIELD
-						Wire.write(uRTCLIB_decToBcd(minute) & 0b01111111 | ((type & 0b00000010) << 7)); // set minutes & mode/bit1
-						uRTCLIB_YIELD
-						Wire.write(uRTCLIB_decToBcd(hour) & 0b01111111 | ((type & 0b00000100) << 6)); // set hours & mode/bit2
-						uRTCLIB_YIELD
-						Wire.write(uRTCLIB_decToBcd(day_dow) & 0b00111111 | ((type & 0b00011000) << 4)); // set date / day of week (1=Sunday, 7=Saturday)  & mode/bit3 & mode/DY-DT (bit4)
-						uRTCLIB_YIELD
-						Wire.endTransmission();
-						uRTCLIB_YIELD
+                    case 0b10000000: // Alarm 2
+                        ret = true;
+                        Wire.beginTransmission(_rtc_address);
+                        uRTCLIB_YIELD
+                        Wire.write(0x07); // set next input to start at the seconds register
+                        uRTCLIB_YIELD
+                        Wire.write((uRTCLIB_decToBcd(minute) & 0b01111111) | ((type & 0b00000010) << 7)); // set minutes & mode/bit1
+                        uRTCLIB_YIELD
+                        Wire.write((uRTCLIB_decToBcd(hour) & 0b01111111) | ((type & 0b00000100) << 6)); // set hours & mode/bit2
+                        uRTCLIB_YIELD
+                        Wire.write((uRTCLIB_decToBcd(day_dow) & 0b00111111) | ((type & 0b00011000) << 4)); // set date / day of week (1=Sunday, 7=Saturday)  & mode/bit3 & mode/DY-DT (bit4)
+                        uRTCLIB_YIELD
+                        Wire.endTransmission();
+                        uRTCLIB_YIELD
 
-						// Enable Alarm:
-						Wire.beginTransmission(_rtc_address);
-						uRTCLIB_YIELD
-						Wire.write(0x0E);
-						uRTCLIB_YIELD
-						Wire.endTransmission();
-						uRTCLIB_YIELD
-						Wire.requestFrom(_rtc_address, 1);
-						uRTCLIB_YIELD
-						status = Wire.read();
-						status = status | 0b00000110;  // INTCN and A2IE bits
-						Wire.beginTransmission(_rtc_address);
-						uRTCLIB_YIELD
-						Wire.write(0x0E);
-						uRTCLIB_YIELD
-						Wire.write(status);
-						uRTCLIB_YIELD
-						Wire.endTransmission();
-						uRTCLIB_YIELD
+                        // Enable Alarm:
+                        Wire.beginTransmission(_rtc_address);
+                        uRTCLIB_YIELD
+                        Wire.write(0x0E);
+                        uRTCLIB_YIELD
+                        Wire.endTransmission();
+                        uRTCLIB_YIELD
+                        Wire.requestFrom(_rtc_address, 1);
+                        uRTCLIB_YIELD
+                        status = Wire.read();
+                        status = status | 0b00000110;  // INTCN and A2IE bits
+                        Wire.beginTransmission(_rtc_address);
+                        uRTCLIB_YIELD
+                        Wire.write(0x0E);
+                        uRTCLIB_YIELD
+                        Wire.write(status);
+                        uRTCLIB_YIELD
+                        Wire.endTransmission();
+                        uRTCLIB_YIELD
 
-						_a2_mode = type;
-						_a2_minute = minute;
-						_a2_hour = hour;
-						_a2_day_dow = day_dow;
-						_sqwg_mode = URTCLIB_SQWG_OFF_1;
+                        _a2_mode = type;
+                        _a2_minute = minute;
+                        _a2_hour = hour;
+                        _a2_day_dow = day_dow;
+                        _sqwg_mode = URTCLIB_SQWG_OFF_1;
 
-						break;
-				} // Alarm type switch
-				break;
-		} // model switch
-		uRTCLIB_YIELD
-	} // if..else
-	return ret;
+                        break;
+                } // Alarm type switch
+                break;
+        } // model switch
+        uRTCLIB_YIELD
+    } // if..else
+    return ret;
 }
 
 
@@ -649,49 +649,49 @@ bool uRTCLib::alarmSet(const uint8_t type, const uint8_t second, const uint8_t m
  * @return false in case of not supported (DS1307) or wrong parameters
  */
 bool uRTCLib::alarmDisable(const uint8_t alarm) {
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return false;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return false;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			uint8_t status, mask = 0;
-			switch (alarm) {
-				case URTCLIB_ALARM_1: // Alarm 1
-					mask = 0b11111110;  // A1IE bit
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            uint8_t status, mask = 0;
+            switch (alarm) {
+                case URTCLIB_ALARM_1: // Alarm 1
+                    mask = 0b11111110;  // A1IE bit
+                    break;
 
-				case URTCLIB_ALARM_2: // Alarm 2
-					mask = 0b11111101;  // A2IE bit
-					break;
-			} // Alarm type switch
-			if (mask) {
-				// Disable Alarm:
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x0E);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				Wire.requestFrom(_rtc_address, 1);
-				status = Wire.read();
-				status &= 0b11111110;  // A1IE bit
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x0E);
-				uRTCLIB_YIELD
-				Wire.write(status);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				_a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
-				return true;
-			}
-			break;
-	} // model switch
-	return false;
+                case URTCLIB_ALARM_2: // Alarm 2
+                    mask = 0b11111101;  // A2IE bit
+                    break;
+            } // Alarm type switch
+            if (mask) {
+                // Disable Alarm:
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x0E);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                Wire.requestFrom(_rtc_address, 1);
+                status = Wire.read();
+                status &= 0b11111110;  // A1IE bit
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x0E);
+                uRTCLIB_YIELD
+                Wire.write(status);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                _a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
+                return true;
+            }
+            break;
+    } // model switch
+    return false;
 }
 
 /**
@@ -704,49 +704,49 @@ bool uRTCLib::alarmDisable(const uint8_t alarm) {
  * @return false in case of not supported (DS1307) or wrong parameters
  */
 bool uRTCLib::alarmClearFlag(const uint8_t alarm) {
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return false;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return false;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			uint8_t status, mask = 0;
-			switch (alarm) {
-				case URTCLIB_ALARM_1: // Alarm 1
-					mask = 0b11111110;
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            uint8_t status, mask = 0;
+            switch (alarm) {
+                case URTCLIB_ALARM_1: // Alarm 1
+                    mask = 0b11111110;
+                    break;
 
-				case URTCLIB_ALARM_2: // Alarm 2
-					mask = 0b11111101;
-					break;
+                case URTCLIB_ALARM_2: // Alarm 2
+                    mask = 0b11111101;
+                    break;
 
-			} // Alarm type switch
-			if (mask) {
-				// Clear Alarm Flag:
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x0F);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				Wire.requestFrom(_rtc_address, 1);
-				status = Wire.read();
-				status &= mask;  // A?F bit
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x0F);
-				uRTCLIB_YIELD
-				Wire.write(status);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				return true;
-			}
-			break;
-	} // model switch
-	return false;
+            } // Alarm type switch
+            if (mask) {
+                // Clear Alarm Flag:
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x0F);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                Wire.requestFrom(_rtc_address, 1);
+                status = Wire.read();
+                status &= mask;  // A?F bit
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x0F);
+                uRTCLIB_YIELD
+                Wire.write(status);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                return true;
+            }
+            break;
+    } // model switch
+    return false;
 }
 
 
@@ -777,26 +777,26 @@ bool uRTCLib::alarmClearFlag(const uint8_t alarm) {
  *     - #URTCLIB_ALARM_TYPE_2_FIXED_DOWHM
  */
 uint8_t uRTCLib::alarmMode(const uint8_t alarm) {
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return 0b11111111;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return 0b11111111;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			switch (alarm) {
-				case URTCLIB_ALARM_1: // Alarm 1
-					return _a1_mode;
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            switch (alarm) {
+                case URTCLIB_ALARM_1: // Alarm 1
+                    return _a1_mode;
+                    break;
 
-				case URTCLIB_ALARM_2: // Alarm 2
-					return _a2_mode;
-					break;
-			} // Alarm type switch
-			break;
-	} // model switch
-	return 0b11111111;
+                case URTCLIB_ALARM_2: // Alarm 2
+                    return _a2_mode;
+                    break;
+            } // Alarm type switch
+            break;
+    } // model switch
+    return 0b11111111;
 }
 
 /**
@@ -809,26 +809,26 @@ uint8_t uRTCLib::alarmMode(const uint8_t alarm) {
  * @return Current stored second. 0b11111111 means error.
  */
 uint8_t uRTCLib::alarmSecond(const uint8_t alarm) {
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return 0b11111111;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return 0b11111111;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			switch (alarm) {
-				case URTCLIB_ALARM_1: // Alarm 1
-					return _a1_second;
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            switch (alarm) {
+                case URTCLIB_ALARM_1: // Alarm 1
+                    return _a1_second;
+                    break;
 
-				case URTCLIB_ALARM_2: // Alarm 2
-					return 0;
-					break;
-			} // Alarm type switch
-			break;
-	} // model switch
-	return 0b11111111;
+                case URTCLIB_ALARM_2: // Alarm 2
+                    return 0;
+                    break;
+            } // Alarm type switch
+            break;
+    } // model switch
+    return 0b11111111;
 }
 
 /**
@@ -841,26 +841,26 @@ uint8_t uRTCLib::alarmSecond(const uint8_t alarm) {
  * @return Current stored minute. 0b11111111 means error.
  */
 uint8_t uRTCLib::alarmMinute(const uint8_t alarm) {
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return 0b11111111;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return 0b11111111;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			switch (alarm) {
-				case URTCLIB_ALARM_1: // Alarm 1
-					return _a1_minute;
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            switch (alarm) {
+                case URTCLIB_ALARM_1: // Alarm 1
+                    return _a1_minute;
+                    break;
 
-				case URTCLIB_ALARM_2: // Alarm 2
-					return _a2_minute;
-					break;
-			} // Alarm type switch
-			break;
-	} // model switch
-	return 0b11111111;
+                case URTCLIB_ALARM_2: // Alarm 2
+                    return _a2_minute;
+                    break;
+            } // Alarm type switch
+            break;
+    } // model switch
+    return 0b11111111;
 }
 
 
@@ -874,26 +874,26 @@ uint8_t uRTCLib::alarmMinute(const uint8_t alarm) {
  * @return Current stored hour. 0b11111111 means error.
  */
 uint8_t uRTCLib::alarmHour(const uint8_t alarm) {
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return 0b11111111;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return 0b11111111;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			switch (alarm) {
-				case URTCLIB_ALARM_1: // Alarm 1
-					return _a1_hour;
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            switch (alarm) {
+                case URTCLIB_ALARM_1: // Alarm 1
+                    return _a1_hour;
+                    break;
 
-				case URTCLIB_ALARM_2: // Alarm 2
-					return _a2_hour;
-					break;
-			} // Alarm type switch
-			break;
-	} // model switch
-	return 0b11111111;
+                case URTCLIB_ALARM_2: // Alarm 2
+                    return _a2_hour;
+                    break;
+            } // Alarm type switch
+            break;
+    } // model switch
+    return 0b11111111;
 }
 
 /**
@@ -906,26 +906,26 @@ uint8_t uRTCLib::alarmHour(const uint8_t alarm) {
  * @return Current stored day or dow. 0b11111111 means error.
  */
 uint8_t uRTCLib::alarmDayDow(const uint8_t alarm) {
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			return 0b11111111;
-			break;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            return 0b11111111;
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			switch (alarm) {
-				case URTCLIB_ALARM_1: // Alarm 1
-					return _a1_day_dow;
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            switch (alarm) {
+                case URTCLIB_ALARM_1: // Alarm 1
+                    return _a1_day_dow;
+                    break;
 
-				case URTCLIB_ALARM_2: // Alarm 2
-					return _a2_day_dow;
-					break;
-			} // Alarm type switch
-			break;
-	} // model switch
-	return 0b11111111;
+                case URTCLIB_ALARM_2: // Alarm 2
+                    return _a2_day_dow;
+                    break;
+            } // Alarm type switch
+            break;
+    } // model switch
+    return 0b11111111;
 }
 
 
@@ -946,125 +946,125 @@ uint8_t uRTCLib::alarmDayDow(const uint8_t alarm) {
  * @return false in case of not supported (DS1307) or wrong parameters
  */
 bool uRTCLib::sqwgSetMode(const uint8_t mode) {
-	uint8_t status, processAnd = 0b00000000, processOr = 0b00000000;
-	uRTCLIB_YIELD
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			switch (mode) {
-				case URTCLIB_SQWG_OFF_0:
-					processAnd = 0b01101111;  // OUT and SQWE bits
-					break;
+    uint8_t status, processAnd = 0b00000000, processOr = 0b00000000;
+    uRTCLIB_YIELD
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            switch (mode) {
+                case URTCLIB_SQWG_OFF_0:
+                    processAnd = 0b01101111;  // OUT and SQWE bits
+                    break;
 
-				case URTCLIB_SQWG_OFF_1:
-					processAnd = 0b11101111; //  SQWE
-					processOr = 0b10000000; // OUT
-					break;
+                case URTCLIB_SQWG_OFF_1:
+                    processAnd = 0b11101111; //  SQWE
+                    processOr = 0b10000000; // OUT
+                    break;
 
-				case URTCLIB_SQWG_1H:
-					processAnd = 0b11111100; //  RS1, RS0
-					processOr = 0b0010000; // SQWE
-					break;
+                case URTCLIB_SQWG_1H:
+                    processAnd = 0b11111100; //  RS1, RS0
+                    processOr = 0b0010000; // SQWE
+                    break;
 
-				case URTCLIB_SQWG_4096H:
-					processAnd = 0b11111101; //  RS1
-					processOr = 0b0010001; // SQWE, RS0
-					break;
+                case URTCLIB_SQWG_4096H:
+                    processAnd = 0b11111101; //  RS1
+                    processOr = 0b0010001; // SQWE, RS0
+                    break;
 
-				case URTCLIB_SQWG_8192H:
-					processAnd = 0b11111110; //  RS0
-					processOr = 0b0010010; // SQWE, RS1
-					break;
+                case URTCLIB_SQWG_8192H:
+                    processAnd = 0b11111110; //  RS0
+                    processOr = 0b0010010; // SQWE, RS1
+                    break;
 
-				case URTCLIB_SQWG_32768H:
-					processAnd = 0b11111111; //  nothing
-					processOr = 0b0010011; // SQWE, RS1, RS0
-					break;
+                case URTCLIB_SQWG_32768H:
+                    processAnd = 0b11111111; //  nothing
+                    processOr = 0b0010011; // SQWE, RS1, RS0
+                    break;
 
-			} // mode switch
+            } // mode switch
 
-			if (processAnd || processOr) { // Any bit change?
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x07);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				Wire.requestFrom(_rtc_address, 1);
-				status = Wire.read();
-				status = status & processAnd | processOr;
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x07);
-				uRTCLIB_YIELD
-				Wire.write(status);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				_sqwg_mode = mode;
-				return true;
-			}
-			break;
+            if (processAnd || processOr) { // Any bit change?
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x07);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                Wire.requestFrom(_rtc_address, 1);
+                status = Wire.read();
+                status = (status & processAnd) | processOr;
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x07);
+                uRTCLIB_YIELD
+                Wire.write(status);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                _sqwg_mode = mode;
+                return true;
+            }
+            break;
 
-		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
-		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
-		default:
-			switch (mode) {
-				case URTCLIB_SQWG_OFF_1:
-					processAnd = 0b11111111; //  nothing
-					processOr = 0b00000100; // INTCN
-					break;
+        // case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+        // case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+        default:
+            switch (mode) {
+                case URTCLIB_SQWG_OFF_1:
+                    processAnd = 0b11111111; //  nothing
+                    processOr = 0b00000100; // INTCN
+                    break;
 
-				case URTCLIB_SQWG_1H:
-					processAnd = 0b11100011; //  RS1, RS0, INTCN
-					processOr = 0b00000000; // nothing
-					break;
+                case URTCLIB_SQWG_1H:
+                    processAnd = 0b11100011; //  RS1, RS0, INTCN
+                    processOr = 0b00000000; // nothing
+                    break;
 
-				case URTCLIB_SQWG_1024H:
-					processAnd = 0b11101011; //  RS1, INTCN
-					processOr = 0b00001000; // RS0
-					break;
+                case URTCLIB_SQWG_1024H:
+                    processAnd = 0b11101011; //  RS1, INTCN
+                    processOr = 0b00001000; // RS0
+                    break;
 
-				case URTCLIB_SQWG_4096H:
-					processAnd = 0b11110011; //  RS0, INTCN
-					processOr = 0b00010000; // RS1
-					break;
+                case URTCLIB_SQWG_4096H:
+                    processAnd = 0b11110011; //  RS0, INTCN
+                    processOr = 0b00010000; // RS1
+                    break;
 
-				case URTCLIB_SQWG_8192H:
-					processAnd = 0b11111011; //  INTCN
-					processOr = 0b00011000; //  RS1, RS0
-					break;
+                case URTCLIB_SQWG_8192H:
+                    processAnd = 0b11111011; //  INTCN
+                    processOr = 0b00011000; //  RS1, RS0
+                    break;
 
-			} // mode switch
+            } // mode switch
 
-			if (processAnd || processOr) { // Any bit change?
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x0E);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				Wire.requestFrom(_rtc_address, 1);
-				status = Wire.read();
-				status = status & processAnd | processOr;
-				Wire.beginTransmission(_rtc_address);
-				uRTCLIB_YIELD
-				Wire.write(0x0E);
-				uRTCLIB_YIELD
-				Wire.write(status);
-				uRTCLIB_YIELD
-				Wire.endTransmission();
-				uRTCLIB_YIELD
-				_sqwg_mode = mode;
-				if (mode == URTCLIB_SQWG_OFF_1 || mode == URTCLIB_SQWG_OFF_0) {
-					_a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
-					_a2_mode = URTCLIB_ALARM_TYPE_2_NONE;
-				}
-				return true;
-			}
-			break;
-	} // model switch
-	uRTCLIB_YIELD
-	return false;
+            if (processAnd || processOr) { // Any bit change?
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x0E);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                Wire.requestFrom(_rtc_address, 1);
+                status = Wire.read();
+                status = (status & processAnd) | processOr;
+                Wire.beginTransmission(_rtc_address);
+                uRTCLIB_YIELD
+                Wire.write(0x0E);
+                uRTCLIB_YIELD
+                Wire.write(status);
+                uRTCLIB_YIELD
+                Wire.endTransmission();
+                uRTCLIB_YIELD
+                _sqwg_mode = mode;
+                if (mode == URTCLIB_SQWG_OFF_1 || mode == URTCLIB_SQWG_OFF_0) {
+                    _a1_mode = URTCLIB_ALARM_TYPE_1_NONE;
+                    _a2_mode = URTCLIB_ALARM_TYPE_2_NONE;
+                }
+                return true;
+            }
+            break;
+    } // model switch
+    uRTCLIB_YIELD
+    return false;
 }
 
 
@@ -1081,7 +1081,7 @@ bool uRTCLib::sqwgSetMode(const uint8_t mode) {
  *     - #URTCLIB_SQWG_32768H
  */
 uint8_t uRTCLib::sqwgMode() {
-	return _sqwg_mode;
+    return _sqwg_mode;
 }
 
 
@@ -1096,32 +1096,32 @@ uint8_t uRTCLib::sqwgMode() {
  * @return content of that position. If any error it will return always 0xFF;
  */
 byte uRTCLib::ramRead(const uint8_t address) {
-	uint8_t offset = 0xff;
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			if (address < 0x38) {
-				offset = 0x08;
-			}
-			break;
+    uint8_t offset = 0xff;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            if (address < 0x38) {
+                offset = 0x08;
+            }
+            break;
 
-		case URTCLIB_MODEL_DS3232:
-			if (address < 0xeb) {
-				offset = 0x14;
-			}
-			break;
-	}
-	if (offset != 0xff) {
-		Wire.beginTransmission(_rtc_address);
-		uRTCLIB_YIELD
-		Wire.write(address + offset);
-		uRTCLIB_YIELD
-		Wire.endTransmission();
-		uRTCLIB_YIELD
-		Wire.requestFrom(_rtc_address, 1);
-		uRTCLIB_YIELD
-		return Wire.read();
-	}
-	return 0xff;
+        case URTCLIB_MODEL_DS3232:
+            if (address < 0xeb) {
+                offset = 0x14;
+            }
+            break;
+    }
+    if (offset != 0xff) {
+        Wire.beginTransmission(_rtc_address);
+        uRTCLIB_YIELD
+        Wire.write(address + offset);
+        uRTCLIB_YIELD
+        Wire.endTransmission();
+        uRTCLIB_YIELD
+        Wire.requestFrom(_rtc_address, 1);
+        uRTCLIB_YIELD
+        return Wire.read();
+    }
+    return 0xff;
 }
 
 
@@ -1134,32 +1134,32 @@ byte uRTCLib::ramRead(const uint8_t address) {
  * @return true if correct
  */
 bool uRTCLib::ramWrite(const uint8_t address, byte data) {
-	uint8_t offset = 0xff;
-	switch (_model) {
-		case URTCLIB_MODEL_DS1307:
-			if (address < 0x38) {
-				offset = 0x08;
-			}
-			break;
+    uint8_t offset = 0xff;
+    switch (_model) {
+        case URTCLIB_MODEL_DS1307:
+            if (address < 0x38) {
+                offset = 0x08;
+            }
+            break;
 
-		case URTCLIB_MODEL_DS3232:
-			if (address < 0xeb) {
-				offset = 0x14;
-			}
-			break;
-	}
-	if (offset != 0xff) {
-		Wire.beginTransmission(_rtc_address);
-		uRTCLIB_YIELD
-		Wire.write(address + offset);
-		uRTCLIB_YIELD
-		Wire.write(data);
-		uRTCLIB_YIELD
-		Wire.endTransmission();
-		uRTCLIB_YIELD
-		return true;
-	}
-	return false;
+        case URTCLIB_MODEL_DS3232:
+            if (address < 0xeb) {
+                offset = 0x14;
+            }
+            break;
+    }
+    if (offset != 0xff) {
+        Wire.beginTransmission(_rtc_address);
+        uRTCLIB_YIELD
+        Wire.write(address + offset);
+        uRTCLIB_YIELD
+        Wire.write(data);
+        uRTCLIB_YIELD
+        Wire.endTransmission();
+        uRTCLIB_YIELD
+        return true;
+    }
+    return false;
 }
 
 

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -1163,5 +1163,4 @@ bool uRTCLib::ramWrite(const uint8_t address, byte data) {
 }
 
 
-
 /*** EEPROM functionality has been moved to separate library: https://github.com/Naguissa/uEEPROMLib ***/


### PR DESCRIPTION
Hi Nagussia,

in uRTCLib.cpp I added a few parenthesis in alarmSet() to avoid warnings.

And since it is a wonderful library, I would like to add an example of setting date by Serial Monitor I could no find in any of the other RTC libraries or other sources.
It also contains some functions for printing the date in 5 different formats (and 2 languages :-))

It would be very nice if you can merge/add this to your repository, for everyones benefit.

Best regards
Armin

P.s. I was not successful to keep the original indentation with my editors, so the diff of uRTCLib.cpp is quite large. Sorry.