### PR TITLE
enableBattery

### DIFF
--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -336,6 +336,63 @@ void uRTCLib::lostPowerClear() {
 	}
 }
 
+
+
+/**
+  *\brief Enable VBAT operation when VCC power is lost.
+  *
+  * DS3231 should enable the battery by default on first power-up using VCC, however this sometimes 
+  * won't happen automatically, and therefore the Control Regsiter needs to be forcefully overwridden
+  * to set EOSC to 0. The devices are usually shipped from China with EOSC set to 1 to save battery 
+  * (even though they come with no battery included).
+  *
+  * Cause of frustration for a lot of first time users of the device. 
+  *   i.e. Time is lost even though battery present.
+  *
+  * Reference: https://forum.arduino.cc/index.php?topic=586520.msg3990086#msg3990086
+  *
+  * @return The value of the Control Register
+  */
+  
+uint8_t uRTCLib::enableBattery() {
+
+	uint8_t status = 0x00;
+
+	switch (_model) {
+		
+		case URTCLIB_MODEL_DS1307:
+		// TODO
+		break;
+	
+		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
+		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
+		default:
+		uRTCLIB_YIELD		
+		Wire.beginTransmission(_rtc_address);
+		uRTCLIB_YIELD
+		Wire.write(0x0E);
+		uRTCLIB_YIELD
+		Wire.write(0b00011100);
+		uRTCLIB_YIELD
+		Wire.endTransmission();
+		
+		// Return the status as a byte, to check against values of Control Register (0Eh)
+		uRTCLIB_YIELD		
+		Wire.beginTransmission(_rtc_address);
+		uRTCLIB_YIELD		
+		Wire.write(0x0E);		
+		uRTCLIB_YIELD
+		Wire.requestFrom(_rtc_address, 1);
+		uRTCLIB_YIELD
+		status =  Wire.read();
+		Wire.endTransmission();		
+
+		break;
+	}	
+		
+		return status;	
+}
+
 /**
  * \brief Returns actual temperature
  *

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -342,7 +342,7 @@ void uRTCLib::lostPowerClear() {
   *\brief Enable VBAT operation when VCC power is lost.
   *
   * DS3231 should enable the battery by default on first power-up using VCC, however this sometimes 
-  * won't happen automatically, and therefore the Control Regsiter needs to be forcefully overwridden
+  * won't happen automatically, and therefore the Control Register needs to be forcefully overwritten
   * to set EOSC to 0. The devices are usually shipped from China with EOSC set to 1 to save battery 
   * (even though they come with no battery included).
   *
@@ -396,7 +396,7 @@ uint8_t uRTCLib::enableBattery() {
 /**
  * \brief Returns actual temperature
  *
- * Temperature is returned as degress * 100; i.e.: 3050 is 30.50º
+ * Temperature is returned as degrees * 100; i.e.: 3050 is 30.50º
  *
  * WARNING: DS1307 has no temperature register, so it always returns #URTCLIB_TEMP_ERROR
  *

--- a/src/uRTCLib.h
+++ b/src/uRTCLib.h
@@ -299,6 +299,7 @@
 			/******* Lost power ********/
 			bool lostPower();
 			void lostPowerClear();
+			uint8_t enableBattery();
 
 			/******** Alarms ************/
 			bool alarmSet(const uint8_t, const uint8_t, const uint8_t, const uint8_t, const uint8_t); // Seconds will be ignored on Alarm 2


### PR DESCRIPTION
Enable function to forcefully set the EOSC register to 0 to enable battery operation. Doesn't always happen automatically.