### PR TITLE
More functionality and bug corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supported features:
 * Alarms (1 and 2) for DS3231 and DS3232
 * Power lost flag reading and clearing
 * Enable Oscillator flag to check if Oscillator will run on VBAT
+* Set Clock in 12 hour or 24 hour mode. Get AM PM if in 12 hour mode. (Alarm set still in 24 hour mode)
 
 EEPROM support has been moved to https://github.com/Naguissa/uEEPROMLib
 
@@ -51,10 +52,10 @@ Included on example folder, available on Arduino IDE.
  - Check .h file to see all constants and per-model limitations
  - Alarm pin is normaly HIGH and turns LOW when active.
  - When using alarms, you need to clear the alarm flag manually using alarmClearFlag(). If not done alarm maintains its LOW state.
- - Alarm Flags A1F and A2F will be triggered whether or not Alarm Interrupt is Enabled A1IE and A2IE
- - When the RTC register values match alarm register settings, the corresponding Alarm Flag ‘A1F’ or ‘A2F’ bit is set to logic 1.
- - If using alarmTriggered function to check for alarm trigger, be sure to alarmMode function to see if alarm is enabled or not.
- - When using alarms SQWG is turned off. When using SQWG alarms are turned off. They're mutually excluding.
+ - Alarm Flags, A1F and A2F, will be triggered whether or not Alarm Interrupts, A1IE and A2IE, are Enabled.
+ - When the RTC register values match alarm register settings, the corresponding Alarm Flag, A1F or A2F, bit is set to logic 1.
+ - If using alarmTriggered function to check for alarm trigger, be sure to check alarmMode function to see if alarm is enabled or not.
+ - When using alarm interrupts, SQWG is turned off. When using SQWG, alarm interrupts are turned off. They're mutually excluding.
 
 
 

--- a/examples/uRTCLib_example_full/uRTCLib_example_full.ino
+++ b/examples/uRTCLib_example_full/uRTCLib_example_full.ino
@@ -9,7 +9,9 @@
  *     * RAM for DS1307 and DS3232
  *     * temperature sensor for DS3231 and DS3232
  *     * Alarms (1 and 2) for DS3231 and DS3232
- *     * Power failure check for DS3231 and DS3232
+ *     * Power lost flag reading and clearing
+ *     * Enable Oscillator flag to check if Oscillator will run on VBAT
+ *     * Set Clock in 12 hour or 24 hour mode. Get AM PM if in 12 hour mode. (Alarm set still in 24 hour mode)
  *
  * See uEEPROMLib for EEPROM support.
  *
@@ -25,6 +27,11 @@
 
 uRTCLib rtc;
 
+// URTCLIB_MODEL_DS1307
+// URTCLIB_MODEL_DS3231
+// URTCLIB_MODEL_DS3232
+byte rtcModel = URTCLIB_MODEL_DS3231;
+
 uint8_t position;
 
 void setup() {
@@ -39,11 +46,22 @@ delay (2000);
 		URTCLIB_WIRE.begin();
 	#endif
 	rtc.set_rtc_address(0x68);
-	rtc.set_model(URTCLIB_MODEL_DS3232);
 
-	// Only used once, then disabled
-	rtc.set(0, 42, 16, 6, 2, 5, 15);
-	//  RTCLib::set(byte second, byte minute, byte hour, byte dayOfWeek, byte dayOfMonth, byte month, byte year)
+	// set RTC Model
+	rtc.set_model(rtcModel);
+
+	// refresh data from RTC HW in RTC class object
+	rtc.refresh();
+
+	// Only use once, then disable
+	// rtc.set(0, 42, 16, 6, 2, 5, 15);
+	//  RTCLib::set(byte second, byte minute, byte hour (0-23:24-hr mode only), byte dayOfWeek (Sun = 1, Sat = 7), byte dayOfMonth (1-12), byte month, byte year)
+
+	// use the following if you want to set main clock in 12 hour mode
+	// rtc.set_12hour_mode(true);
+
+	// use the following if you want to set main clock in 24 hour mode
+	// rtc.set_12hour_mode(false);
 
 	if (rtc.enableBattery()) {
 		Serial.println("Battery activated correctly.");
@@ -52,9 +70,10 @@ delay (2000);
 	}
 
 	// Check whether OSC is set to use VBAT or not
-	if (rtc.getEOSCFlag()) {
+	if (rtc.getEOSCFlag())
 		Serial.println(F("Oscillator will not use VBAT when VCC cuts off. Time will not increment without VCC!"));
-	}
+	else
+		Serial.println(F("Oscillator will use VBAT when VCC cuts off."));
 
 	Serial.print("Lost power status: ");
 	if (rtc.lostPower()) {
@@ -108,12 +127,14 @@ delay (2000);
 		rtc.ramWrite(position, position);
 	}
 
-	rtc.alarmClearFlag(URTCLIB_ALARM_1);
-	rtc.alarmClearFlag(URTCLIB_ALARM_2);
+	if(rtcModel == URTCLIB_MODEL_DS3231 || rtcModel == URTCLIB_MODEL_DS3232) {
+		rtc.alarmClearFlag(URTCLIB_ALARM_1);
+		rtc.alarmClearFlag(URTCLIB_ALARM_2);
 
-	// Alarm pin will get low at sny :10 seconds. We clear the flag on loop to be able to see it, as it doesn't clear itself when triggered
-	rtc.alarmSet(URTCLIB_ALARM_TYPE_1_FIXED_S, 10, 0, 0, 1); // Each minute, at just :10 seconds
-	// RTCLib::alarmSet(uint8_t type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day_dow);
+		// Alarm pin will get low at sny :10 seconds. We clear the flag on loop to be able to see it, as it doesn't clear itself when triggered
+		rtc.alarmSet(URTCLIB_ALARM_TYPE_1_FIXED_S, 10, 0, 0, 1); // Each minute, at just :10 seconds
+		// RTCLib::alarmSet(uint8_t type, uint8_t second, uint8_t minute, uint8_t hour, uint8_t day_dow);
+	}
 
 	position = 0;
 
@@ -136,6 +157,10 @@ void loop() {
 	Serial.print(rtc.minute());
 	Serial.print(':');
 	Serial.print(rtc.second());
+	if(rtc.hourModeAndAmPm() == 1)
+		Serial.print(" AM");
+	if(rtc.hourModeAndAmPm() == 2)
+		Serial.print(" PM");
 
 	Serial.print(" DOW: ");
 	Serial.print(rtc.dayOfWeek());
@@ -143,18 +168,20 @@ void loop() {
 	Serial.print(" - Temp: ");
 	Serial.print((float) rtc.temp() / 100);
 
-	Serial.print(" - SRAM position ");
-	Serial.print(position);
-	Serial.print(" value: ");
-	Serial.print(rtc.ramRead(position), HEX);
+	if(rtcModel == URTCLIB_MODEL_DS1307 || rtcModel == URTCLIB_MODEL_DS3232) {
+		Serial.print(" - SRAM position ");
+		Serial.print(position);
+		Serial.print(" value: ");
+		Serial.print(rtc.ramRead(position), HEX);
+		position++;
+	}
 
 	Serial.println();
 
-	rtc.alarmClearFlag(URTCLIB_ALARM_1);
-	rtc.alarmClearFlag(URTCLIB_ALARM_2);
-
-
-	position++;
+	if(rtcModel == URTCLIB_MODEL_DS3231 || rtcModel == URTCLIB_MODEL_DS3232) {
+		rtc.alarmClearFlag(URTCLIB_ALARM_1);
+		rtc.alarmClearFlag(URTCLIB_ALARM_2);
+	}
 
 	delay(1000);
 }

--- a/examples/uRTCLib_example_full/uRTCLib_example_full.ino
+++ b/examples/uRTCLib_example_full/uRTCLib_example_full.ino
@@ -35,7 +35,7 @@ byte rtcModel = URTCLIB_MODEL_DS3231;
 uint8_t position;
 
 void setup() {
-delay (2000);
+	delay (2000);
 	Serial.begin(9600);
 	Serial.println("Serial OK");
 	//  Max position: 32767
@@ -50,7 +50,7 @@ delay (2000);
 	// set RTC Model
 	rtc.set_model(rtcModel);
 
-	// refresh data from RTC HW in RTC class object
+	// refresh data from RTC HW in RTC class object so flags like rtc.lostPower(), rtc.getEOSCFlag(), etc, can get populated
 	rtc.refresh();
 
 	// Only use once, then disable

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -1046,6 +1046,7 @@ bool uRTCLib::alarmClearFlag(const uint8_t alarm) {
 				URTCLIB_WIRE.requestFrom(_rtc_address, 1);
 				status = URTCLIB_WIRE.read();
 				status &= mask;  // A?F bit
+				_controlStatus &= mask;	// clear alarm triggered flags on _controlStatus as well
 				URTCLIB_WIRE.beginTransmission(_rtc_address);
 				uRTCLIB_YIELD
 				URTCLIB_WIRE.write(0x0F);

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -255,6 +255,7 @@ void uRTCLib::refresh() {
 			// 0x0Fh
 			LSB = URTCLIB_WIRE.read(); //Control
 			uRTCLIB_YIELD
+			// Serial.print("0x0Fh "); Serial.println(LSB, BIN);
 			_controlStatus = LSB;
 			if(_eosc) _controlStatus |= 0b01000000;
 			if(_12hrMode) _controlStatus |= 0b00100000;
@@ -341,15 +342,15 @@ void uRTCLib::lostPowerClear() {
 	_controlStatus &= 0b01111111;	// clear lost power status
 	switch (_model) {
 		case URTCLIB_MODEL_DS1307:
-			uRTCLIB_YIELD
 			URTCLIB_WIRE.beginTransmission(_rtc_address);
-			URTCLIB_WIRE.write(0X00);
+			uRTCLIB_YIELD
+			URTCLIB_WIRE.write(0x00);
+			uRTCLIB_YIELD
 			URTCLIB_WIRE.endTransmission();
 			uRTCLIB_YIELD
 			URTCLIB_WIRE.requestFrom(_rtc_address, 1);
 			status = URTCLIB_WIRE.read();
 			status &= 0b01111111;
-			uRTCLIB_YIELD
 			URTCLIB_WIRE.beginTransmission(_rtc_address);
 			uRTCLIB_YIELD
 			URTCLIB_WIRE.write(0x00);
@@ -363,15 +364,15 @@ void uRTCLib::lostPowerClear() {
 		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode
 		// case URTCLIB_MODEL_DS3232: // Commented out because it's default mode
 		default:
-			uRTCLIB_YIELD
 			URTCLIB_WIRE.beginTransmission(_rtc_address);
-			URTCLIB_WIRE.write(0X0F);
+			uRTCLIB_YIELD
+			URTCLIB_WIRE.write(0x0F);
+			uRTCLIB_YIELD
 			URTCLIB_WIRE.endTransmission();
 			uRTCLIB_YIELD
 			URTCLIB_WIRE.requestFrom(_rtc_address, 1);
 			status = URTCLIB_WIRE.read();
 			status &= 0b01111111;
-			uRTCLIB_YIELD
 			URTCLIB_WIRE.beginTransmission(_rtc_address);
 			uRTCLIB_YIELD
 			URTCLIB_WIRE.write(0x0F);

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -436,6 +436,8 @@ bool uRTCLib::enableBattery() {
 			uRTCLIB_YIELD
 			URTCLIB_WIRE.write(0x0E);
 			uRTCLIB_YIELD
+			URTCLIB_WIRE.endTransmission();
+			uRTCLIB_YIELD
 			URTCLIB_WIRE.requestFrom(_rtc_address, 1);
 			uRTCLIB_YIELD
 			status =  URTCLIB_WIRE.read();

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -334,6 +334,8 @@ bool uRTCLib::lostPower() {
  */
 void uRTCLib::lostPowerClear() {
 	uint8_t status;
+	// _lost_power = (bool) (_controlStatus & 0b10000000);
+	_controlStatus &= 0b01111111;	// clear lost power status
 	switch (_model) {
 		case URTCLIB_MODEL_DS1307:
 			uRTCLIB_YIELD
@@ -1539,6 +1541,8 @@ bool uRTCLib::agingSet(int8_t val) {
  * As DS1307 doen't have this functionality we map it to SqWG with 32K frequency
  */
 bool uRTCLib::enable32KOut() {
+	//_32k = (bool) (_controlStatus & 0b00001000);
+	_controlStatus |= 0b00001000;
 	switch (_model) {
 		case URTCLIB_MODEL_DS1307: // As DS1307 doesn't have this pin, map it to SqWG at same frequency
 			return sqwgSetMode(URTCLIB_SQWG_32768H);
@@ -1576,6 +1580,8 @@ bool uRTCLib::enable32KOut() {
  * As DS1307 doen't have this functionality we map it to SqWG with 32K frequency
  */
 bool uRTCLib::disable32KOut() {
+	//_32k = (bool) (_controlStatus & 0b00001000);
+	_controlStatus &= 0b11110111;
 	switch (_model) {
 		case URTCLIB_MODEL_DS1307: // As DS1307 doesn't have this pin, map it to SqWG at same frequency
 			return sqwgSetMode(URTCLIB_SQWG_OFF_0);

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -249,7 +249,7 @@ void uRTCLib::refresh() {
 			uRTCLIB_YIELD
 
 			_controlStatus = LSB;
-			_controlStatus |= _eosc & 0b01000000;
+			if(_eosc) _controlStatus |= 0b01000000;
 			// _lost_power = (bool) (_controlStatus & 0b10000000);
 			// _eosc = (bool) (_controlStatus & 0b01000000);
 			// _32k = (bool) (_controlStatus & 0b00001000);
@@ -296,7 +296,7 @@ void uRTCLib::refresh() {
  * @return _eosc flag - 0 if set to enable OSC with VBAT if VCC is stopped
  */
 bool uRTCLib::getEOSCFlag() {
-	return (bool) (_controlStatus & 0b0000000);
+	return (bool) (_controlStatus & 0b01000000);
 }
 
 /**

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -102,9 +102,7 @@ void uRTCLib::refresh() {
 	// 0x02h
 	_hour = URTCLIB_WIRE.read() & 0b01111111;
 	uRTCLIB_YIELD
-	Serial.println();
-	Serial.print("_hour BIN "); Serial.println(_hour, BIN);
-	_12hrMode = (bool) (_hour & 0b01000000);
+	bool _12hrMode = (bool) (_hour & 0b01000000);
 	if(_12hrMode) {
 		_pmNotAm = (bool) (_hour & 0b00100000);
 		_hour = _hour & 0b00011111;
@@ -113,9 +111,6 @@ void uRTCLib::refresh() {
 		_hour = _hour & 0b00111111;
 	}
 	_hour = uRTCLIB_bcdToDec(_hour);
-	Serial.print("_12hrMode "); Serial.println(_12hrMode);
-	Serial.print("_pmNotAm "); Serial.println(_pmNotAm);
-	Serial.print("_hour DEC "); Serial.println(_hour, DEC);
 
 	// 0x03h
 	_dayOfWeek = URTCLIB_WIRE.read();
@@ -263,7 +258,6 @@ void uRTCLib::refresh() {
 			_controlStatus = LSB;
 			if(_eosc) _controlStatus |= 0b01000000;
 			if(_12hrMode) _controlStatus |= 0b00100000;
-			Serial.print("_controlStatus "); Serial.println(_controlStatus, BIN);
 			// _lost_power = (bool) (_controlStatus & 0b10000000);
 			// _eosc = (bool) (_controlStatus & 0b01000000);
 			// _12hrMode = (bool) (_controlStatus & 0b00100000);
@@ -706,15 +700,17 @@ bool uRTCLib::set_hour_mode_and_am_pm(const uint8_t clockMode, const uint8_t hou
 	byte hour_bcd = uRTCLIB_decToBcd(hour);
 	_hour = hour;
 	if(clockMode) {
-		_12hrMode = true;
+		// _12hrMode = true;
+		_controlStatus |= 0b00100000;
 		_pmNotAm = (bool)(clockMode - 1);
 		hour_bcd |= 0B01000000;
 		if(_pmNotAm) hour_bcd |= 0B00100000;
 	}
 	else {
-		_12hrMode = false;
+		// _12hrMode = false;
+		_controlStatus &= 0b11011111;
 	}
-	_controlStatus |= _12hrMode & 0b00100000;
+	
 	// set hour register byte
 	uRTCLIB_YIELD
 	URTCLIB_WIRE.beginTransmission(_rtc_address);

--- a/src/uRTCLib.h
+++ b/src/uRTCLib.h
@@ -338,6 +338,16 @@
 			 */
 			uint8_t hour();
 			/**
+			 * \brief Returns whether clock is in 12 or 24 hour mode
+			 * and AM or PM if in 12 hour mode
+			 * 0 = 24 hour mode (0-23 hours)
+			 * 1 = 12 hour mode AM hours (1-12 hours)
+			 * 2 = 12 hour mode PM hours (1-12 hours)
+			 *
+			 * @return byte with value 0, 1 or 2
+			 */
+			uint8_t hourModeAndAmPm();
+			/**
 			 * \brief Returns actual day
 			 *
 			 * @return Current stored day
@@ -398,6 +408,19 @@
 			 */
 			void set(const uint8_t, const uint8_t, const uint8_t, const uint8_t, const uint8_t, const uint8_t, const uint8_t);
 			/**
+			 * \brief Set clock in 12 or 24 hour mode
+			 * along with AM or PM if in 12 hour mode
+			 * 0 = 24 hour mode (0-23 hours)
+			 * 1 = 12 hour mode AM hours (1-12 hours)
+			 * 2 = 12 hour mode PM hours (1-12 hours)
+			 *
+			 * @param clockMode with value 0, 1 or 2
+			 * @param hour hour to set to HW RTC
+			 *
+			 * @return false in case of wrong parameters
+			 */
+			bool set_hour_mode_and_am_pm(const uint8_t, const uint8_t);
+			/**
 			 * \brief Sets RTC i2 addres
 			 *
 			 * @param addr RTC i2C address
@@ -423,19 +446,19 @@
 			uint8_t model();
 
 			/******* Power ********/
-      /**
-      * \brief Returns Enable Oscillator Flah
-      *
-      * DS3231 Control Register (0Eh) Bit 7: Enable Oscillator (EOSC)
-      * When set to logic 0, the oscillator is started. When set to logic 1, the oscillator
-      * is stopped when the DS3231 switches to VBAT. This bit is clear (logic 0) when power 
-      * is first applied. When the DS3231 is powered by VCC, the oscillator is always on
-      * regardless of the status of the EOSC bit. When EOSC is disabled, all register data 
-      * is static.
-      *
-      * @return _eosc flag - 0 if set to enable OSC with VBAT if VCC is stopped
-      */
-      bool getEOSCFlag();
+			/**
+			 * \brief Returns Enable Oscillator Flag
+			 *
+			 * DS3231 Control Register (0Eh) Bit 7: Enable Oscillator (EOSC)
+			 * When set to logic 0, the oscillator is started. When set to logic 1, the oscillator
+			 * is stopped when the DS3231 switches to VBAT. This bit is clear (logic 0) when power
+			 * is first applied. When the DS3231 is powered by VCC, the oscillator is always on
+			 * regardless of the status of the EOSC bit. When EOSC is disabled, all register data
+			 * is static.
+			 *
+			 * @return _eosc flag - 0 if set to enable OSC with VBAT if VCC is stopped
+			 */
+			bool getEOSCFlag();
 			/**
 			 * \brief Returns lost power VBAT staus
 			 *
@@ -743,9 +766,15 @@
 			// SQWG
 			uint8_t _sqwg_mode = URTCLIB_SQWG_OFF_1;
 
+			// 12 hour or 24 hour mode
+			bool _12hrMode = false;
+			// am or pm
+			bool _pmNotAm = false;
+
 			// Keep record of various Flags
 			// _lost_power = (bool) (_controlStatus & 0b10000000);
 			// _eosc = (bool) (_controlStatus & 0b01000000);
+			// _12hrMode = (bool) (_controlStatus & 0b00100000);
 			// _32k = (bool) (_controlStatus & 0b00001000);
 			// _a1_triggered_flag = (bool) (_controlStatus & 0b00000001);
 			// _a2_triggered_flag = (bool) (_controlStatus & 0b00000010);

--- a/src/uRTCLib.h
+++ b/src/uRTCLib.h
@@ -409,17 +409,13 @@
 			void set(const uint8_t, const uint8_t, const uint8_t, const uint8_t, const uint8_t, const uint8_t, const uint8_t);
 			/**
 			 * \brief Set clock in 12 or 24 hour mode
-			 * along with AM or PM if in 12 hour mode
-			 * 0 = 24 hour mode (0-23 hours)
-			 * 1 = 12 hour mode AM hours (1-12 hours)
-			 * 2 = 12 hour mode PM hours (1-12 hours)
+			 * 12 hour mode has 1-12 hours and AM or PM flag
+			 * 24 hour mode has 0-23 hours
+			 * get current clock mode and AM or PM flag using hourModeAndAmPm()
 			 *
-			 * @param clockMode with value 0, 1 or 2
-			 * @param hour hour to set to HW RTC
-			 *
-			 * @return false in case of wrong parameters
+			 * @param twelveHrMode true or false
 			 */
-			bool set_hour_mode_and_am_pm(const uint8_t, const uint8_t);
+			void set_12hour_mode(const bool);
 			/**
 			 * \brief Sets RTC i2 addres
 			 *

--- a/src/uRTCLib.h
+++ b/src/uRTCLib.h
@@ -738,7 +738,6 @@
 			uint8_t _minute = 0;
 			uint8_t _hour = 0;
 			uint8_t _day = 0;
-			bool _pmNotAm = false;		// am or pm if 12 hour mode, _12hrMode in _controlStatus
 			uint8_t _month = 0;
 			uint8_t _year = 0;
 			uint8_t _dayOfWeek = 0;
@@ -753,13 +752,13 @@
 			uint8_t _a1_minute = 0;
 			uint8_t _a1_hour = 0;
 			uint8_t _a1_day_dow = 0;
-			//bool _a1_triggered_flag = (bool) (_controlStatus & 0b00000001);
+			//bool _a1_triggered_flag = _controlStatus  LSB Bit 0
 
 			uint8_t _a2_mode = URTCLIB_ALARM_TYPE_2_NONE;
 			uint8_t _a2_minute = 0;
 			uint8_t _a2_hour = 0;
 			uint8_t _a2_day_dow = 0;
-			// bool _a2_triggered_flag = (bool) (_controlStatus & 0b00000010);
+			// bool _a2_triggered_flag = _controlStatus  Bit 1
 
 			// Aging
 			int8_t _aging = 0;
@@ -768,12 +767,14 @@
 			uint8_t _sqwg_mode = URTCLIB_SQWG_OFF_1;
 
 			// Keep record of various Flags
-			// _lost_power = (bool) (_controlStatus & 0b10000000);
-			// _eosc = (bool) (_controlStatus & 0b01000000);
-			// _12hrMode = (bool) (_controlStatus & 0b00100000);
-			// _32k = (bool) (_controlStatus & 0b00001000);
-			// _a1_triggered_flag = (bool) (_controlStatus & 0b00000001);
-			// _a2_triggered_flag = (bool) (_controlStatus & 0b00000010);
+			// _controlStatus  MSB Bit 7    _lost_power        = (bool) (_controlStatus & 0b10000000);
+			// _controlStatus  Bit 6        _eosc              = (bool) (_controlStatus & 0b01000000);
+			// _controlStatus  Bit 5        _12hrMode          = (bool) (_controlStatus & 0b00100000);
+			// _controlStatus  Bit 4        _pmNotAm           = (bool) (_controlStatus & 0b00010000);    // am or pm if 12 hour mode
+			// _controlStatus  Bit 3        _32k               = (bool) (_controlStatus & 0b00001000);
+			// _controlStatus  Bit 2
+			// _controlStatus  Bit 1        _a2_triggered_flag = (bool) (_controlStatus & 0b00000010);
+			// _controlStatus  LSB Bit 0    _a1_triggered_flag = (bool) (_controlStatus & 0b00000001);
 			uint8_t _controlStatus = 0x00;
 
 	};

--- a/src/uRTCLib.h
+++ b/src/uRTCLib.h
@@ -738,6 +738,7 @@
 			uint8_t _minute = 0;
 			uint8_t _hour = 0;
 			uint8_t _day = 0;
+			bool _pmNotAm = false;		// am or pm if 12 hour mode, _12hrMode in _controlStatus
 			uint8_t _month = 0;
 			uint8_t _year = 0;
 			uint8_t _dayOfWeek = 0;
@@ -765,11 +766,6 @@
 
 			// SQWG
 			uint8_t _sqwg_mode = URTCLIB_SQWG_OFF_1;
-
-			// 12 hour or 24 hour mode
-			bool _12hrMode = false;
-			// am or pm
-			bool _pmNotAm = false;
 
 			// Keep record of various Flags
 			// _lost_power = (bool) (_controlStatus & 0b10000000);


### PR DESCRIPTION
 Hello Naguissa,

Here is some more functionality and bug corrections:
- I2C communication blocking bug in enableBattery() and disableBattery() mostly hitting on ESP32 and sometimes on Atmega328p. enableBattery() not always working bug. Closes #27 
- addition of 12 hour / 24 hour clock mode select functionality
- flag to know if clock is in 12 hour / 24 hour mode and also AM-PM if in 12 hour mode
- added 12-24 hour mode select comment on example; a print statement that'll print AM-PM if in 12 hour mode
- model check before accessing SRAM or alarms, refresh() needs to be called before calling lostPower()
- bug correction on eosc flag, introduced in my last commit
- bug correction on not noting alarmClearFlag while clearing alarm flags, introduced in my last commit
- tabs replace spaces, introduced in my last commit
- tested all functionalities on Atmega328p and ESP32.

That's it! Thank you!