### PR TITLE
Add error checking to refresh()

### DIFF
--- a/src/uRTCLib.h
+++ b/src/uRTCLib.h
@@ -318,7 +318,7 @@
 			/**
 			 * \brief Refresh data from HW RTC
 			 */
-			void refresh();
+			bool refresh();
 			/**
 			 * \brief Returns actual second
 			 *


### PR DESCRIPTION
Return type of `refresh()` changed from `void` to `bool`.
Returns `false` if no response was received, or fewer than the expected number of bytes of response for the selected model; otherwise `true`. 

This enables the caller to check whether the RTC could be successfully contacted, before going ahead and using it. Without it, all we can do is blindly assume that it's present and working, which can result in (a) nonsense values being used and (b) long delays while the I2C bus gives repeated errors.