### PR TITLE
DS3232 has 236 bytes of SRAM, but only 235 were accessible

### DIFF
--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -1460,7 +1460,7 @@ byte uRTCLib::ramRead(const uint8_t address) {
 			break;
 
 		case URTCLIB_MODEL_DS3232:
-			if (address < 0xeb) {
+			if (address < 0xec) {
 				offset = 0x14;
 			}
 			break;
@@ -1498,7 +1498,7 @@ bool uRTCLib::ramWrite(const uint8_t address, byte data) {
 			break;
 
 		case URTCLIB_MODEL_DS3232:
-			if (address < 0xeb) {
+			if (address < 0xec) {
 				offset = 0x14;
 			}
 			break;


### PR DESCRIPTION
The address checks for reading and writing SRAM on the DS3232 were off by one, making the last byte inaccessible.