### PR TITLE
Added build flag for selecting Wire1 instead of Wire

### DIFF
--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -40,7 +40,11 @@
 		#define URTCLIB_WIRE TinyWireM
 	#else
 		#include <Wire.h>
-		#define URTCLIB_WIRE Wire
+        #ifdef URTCLIB_USE_WIRE1
+            #define URTCLIB_WIRE Wire1
+        #else
+            #define URTCLIB_WIRE Wire
+        #endif
 	#endif
 #endif
 #include "uRTCLib.h"

--- a/src/uRTCLib.h
+++ b/src/uRTCLib.h
@@ -45,7 +45,11 @@
 			#define URTCLIB_WIRE TinyWireM
 		#else
 			#include <Wire.h>
-			#define URTCLIB_WIRE Wire
+            #ifdef URTCLIB_USE_WIRE1
+                #define URTCLIB_WIRE Wire1
+            #else
+                #define URTCLIB_WIRE Wire
+            #endif
 		#endif
 	#endif
 


### PR DESCRIPTION
Added additional build flag "URTCLIB_USE_WIRE1", to be able, to use Wire1 I2C interface instead of Wire. 