### PR TITLE
Update _controlStatus byte on refresh() for DS1307 as well

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=uRTCLib
-version=6.9.3
+version=6.9.4
 author=Naguissa <naguissa@foroelectro.net>
 maintainer=Naguissa <naguissa@foroelectro.net>
 sentence=Really tiny library to basic RTC functionality on Arduino. DS1307, DS3231 and DS3232 RTCs are supported. See https://github.com/Naguissa/uEEPROMLib for EEPROM support. Temperature, Alarms, SQWG, Power lost and RAM support.

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -116,6 +116,7 @@ bool uRTCLib::refresh() {
 	// 0x02h
 	_hour = URTCLIB_WIRE.read() & 0b01111111;
 	uRTCLIB_YIELD
+	// Serial.print("0x02h "); Serial.println(_hour, BIN);
 	bool _12hrMode = (bool) (_hour & 0b01000000);
 	bool _pmNotAm = (bool) (_hour & 0b00100000);
 	if(_12hrMode)
@@ -174,6 +175,11 @@ bool uRTCLib::refresh() {
 						break;
 				}
 			}
+			_controlStatus = 0;
+			if(_12hrMode) _controlStatus |= 0b00100000;
+			if(_pmNotAm) _controlStatus |= 0b00010000;
+			if(_sqwg_mode == URTCLIB_SQWG_32768H) _controlStatus |= 0b00001000;
+			// Serial.print("_controlStatus "); Serial.println(_controlStatus, BIN);
 			break;
 
 		// case URTCLIB_MODEL_DS3231: // Commented out because it's default mode


### PR DESCRIPTION
Minor bug that got introduced when _controlStatus byte was introduced to library. Earlier functioning was tested with DS3231 only. Now with both DS3231 and DS1307. Code flow is similar for DS3231 and DS3232, so DS3232 should also work well if DS3231 works well.