### PR TITLE
Add parentheses on bitwise operation for correct operation

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=uRTCLib
-version=6.9.4
+version=6.9.5
 author=Naguissa <naguissa@foroelectro.net>
 maintainer=Naguissa <naguissa@foroelectro.net>
 sentence=Really tiny library to basic RTC functionality on Arduino. DS1307, DS3231 and DS3232 RTCs are supported. See https://github.com/Naguissa/uEEPROMLib for EEPROM support. Temperature, Alarms, SQWG, Power lost and RAM support.

--- a/src/uRTCLib.cpp
+++ b/src/uRTCLib.cpp
@@ -110,10 +110,15 @@ bool uRTCLib::refresh() {
 	// It is placed on 1st bit of 1st byte.
 	// So use that flag to mark both
 	if (_model == URTCLIB_MODEL_DS1307) {
-    	_controlStatus |= ((tempByte >> 1) & 0b01000000) | (tempByte & 0b10000000);
+    	_controlStatus |= (((tempByte >> 1) & 0b01000000) | (tempByte & 0b10000000));
 	}
 	uRTCLIB_YIELD
-	_second = uRTCLIB_bcdToDec(tempByte & 0b01111111);
+	// Parantheses reqired on bitwise operation for correct uRTCLIB_bcdToDec operation
+	// Serial.print("byte_00h "); Serial.println(tempByte, BIN);
+	// Serial.print("byte_00h_bcdToDec_with_parantheses "); Serial.println(uRTCLIB_bcdToDec((tempByte & 0b01111111)));
+	// Serial.print("byte_00h_bcdToDec_without_parantheses "); Serial.println(uRTCLIB_bcdToDec(tempByte & 0b01111111));
+	_second = uRTCLIB_bcdToDec((tempByte & 0b01111111));
+	// Serial.print("_second "); Serial.println(_second);
 
 	// 0x01h
 	_minute = URTCLIB_WIRE.read() & 0b01111111;


### PR DESCRIPTION
Without parantheses bcd_to_dec operation was not working as expected:

byte_00h 100
byte_00h_bcdToDec_with_parantheses 4
byte_00h_bcdToDec_without_parantheses 8

byte_00h 10110
byte_00h_bcdToDec_with_parantheses 16
byte_00h_bcdToDec_without_parantheses 12

byte_00h 100010
byte_00h_bcdToDec_with_parantheses 22
byte_00h_bcdToDec_without_parantheses 4

byte_00h 111000
byte_00h_bcdToDec_with_parantheses 38
byte_00h_bcdToDec_without_parantheses 8

byte_00h 1000010
byte_00h_bcdToDec_with_parantheses 42
byte_00h_bcdToDec_without_parantheses 68

byte_00h 1010110
byte_00h_bcdToDec_with_parantheses 56
byte_00h_bcdToDec_without_parantheses 76

byte_00h 1011001
byte_00h_bcdToDec_with_parantheses 59
byte_00h_bcdToDec_without_parantheses 73